### PR TITLE
Fix makefile warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@
 run:
 	(PYTHONPATH=$(shell pwd) bin/probert)
 
-make lint:
+lint:
 	echo "Running flake8 lint tests..."
 	flake8 bin/probert --ignore=F403
 	flake8 --exclude probert/tests/ probert --ignore=F403
 
-make unit:
+unit:
 	echo "Running unit tests..."
 	python3 -m "nose" -v --nologcapture --with-coverage probert/tests/


### PR DESCRIPTION
Cut-n-paste error which included make in the target name.
Don't do that.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
