### PR TITLE
Handle unprintable output in attribute decoding

### DIFF
--- a/probert/utils.py
+++ b/probert/utils.py
@@ -23,5 +23,5 @@ def dict_merge(onto, source):
 def udev_get_attribute(device, key):
     val = device.attributes.get(key)
     if isinstance(val, bytes):
-        return val.decode('utf-8')
+        return val.decode('utf-8', 'replace')
     return val


### PR DESCRIPTION
When decoding device attributes, ensure we don't
attempt to handle unprintable by replacing the output.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
