### PR TITLE
Populate empty ifaddresses dictionary with keys

### DIFF
--- a/probert/network.py
+++ b/probert/network.py
@@ -30,8 +30,13 @@ class Network():
         return netifaces.interfaces()
 
     def get_ips(self, iface):
-        """ returns dictionary with keys: addr, netmask, broadcast """
-        return netifaces.ifaddresses(iface).get(netifaces.AF_INET, [{}])
+        """ returns list of dictionary with keys: addr, netmask, broadcast """
+        empty = {
+            'addr': None,
+            'netmask': None,
+            'broadcast': None,
+        }
+        return netifaces.ifaddresses(iface).get(netifaces.AF_INET, [empty])
 
     def get_hwaddr(self, iface):
         """ returns dictionary with keys: addr, broadcast """


### PR DESCRIPTION
Unconfigured ip on interfaces returned an empty dictionary
which kept the 'ip' key from being populated.  Instead we
always want the 'ip' to have a dictionary and we populate
the values of the keys with None.

This fixes issue 6 on github.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
