### PR TITLE
Add --all cli option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Makefile for probert
 #
 run:
-	(PYTHONPATH=$(shell pwd) bin/probert)
+	(PYTHONPATH=$(shell pwd) bin/probert --all)
 
 lint:
 	echo "Running flake8 lint tests..."

--- a/bin/probert
+++ b/bin/probert
@@ -24,12 +24,16 @@ def parse_options(argv):
     parser = argparse.ArgumentParser(
         description='probert - Hardware prober for all',
         prog='probert')
+    parser.add_argument('--all', action='store_true',
+                        default=False,
+                        dest='probe_all',
+                        help='Probe all hardware types.')
     parser.add_argument('--storage', action='store_true',
-                        default=True,
+                        default=False,
                         dest='probe_storage',
                         help='Probe storage hardware.')
     parser.add_argument('--network', action='store_true',
-                        default=True,
+                        default=False,
                         dest='probe_network',
                         help='Probe network hardware.')
     return parser.parse_args(argv)


### PR DESCRIPTION
Implement cli option to invoke all probe options.
Modify prober class to invoke all probe_ functions
when called with probe_all option set.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
