### PR TITLE
Port to properly handling pyudev 0.18 changes.

### DIFF
--- a/probert/network.py
+++ b/probert/network.py
@@ -508,7 +508,7 @@ class Network():
             hardware = dict(device)
             hardware.update(
                 {'attrs': dict([(key, udev_get_attribute(device, key))
-                                for key in device.attributes])})
+                                for key in device.attributes.available_attributes])})
             results = dict_merge(results, {iface: {'hardware': hardware}})
 
             [af_inet] = self._get_ips(iface)

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -161,7 +161,7 @@ class Storage():
         for device in self.context.list_devices(subsystem='block'):
             if device['MAJOR'] not in ["1", "7"]:
                 attrs = dict([(key, udev_get_attribute(device, key))
-                              for key in device.attributes])
+                              for key in device.attributes.available_attributes])
                 # update the size attr as it may only be the number
                 # of blocks rather than size in bytes.
                 attrs['size'] = \


### PR DESCRIPTION
Yakkety has a newer pyudev (> 0.18), but 0.18 introduced Attributes that are no longer extending Mapping, and thus no longer iterable. probert needs to use the new available_attributes to get the attribute names, which may still be unset.

Signed-off-by: Mathieu Trudel-Lapierre mathieu.trudel-lapierre@canonical.com
