### PR TITLE
lvm: don't use vgscan --mknodes

### DIFF
--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -91,7 +91,7 @@ def lvmetad_running():
 
 
 def lvm_scan():
-    for cmd in [['pvscan'], ['vgscan', '--mknodes']]:
+    for cmd in [['pvscan'], ['vgscan']]:
         if lvmetad_running():
             cmd.append('--cache')
         try:

--- a/probert/tests/test_lvm.py
+++ b/probert/tests/test_lvm.py
@@ -178,7 +178,7 @@ class TestLvm(testtools.TestCase):
         m_run.assert_has_calls([
           mock.call(['pvscan', '--cache'],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL),
-          mock.call(['vgscan', '--mknodes', '--cache'],
+          mock.call(['vgscan', '--cache'],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)])
 
     @mock.patch('probert.lvm.lvmetad_running')
@@ -193,7 +193,7 @@ class TestLvm(testtools.TestCase):
         m_run.assert_has_calls([
           mock.call(['pvscan', '--cache'],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL),
-          mock.call(['vgscan', '--mknodes', '--cache'],
+          mock.call(['vgscan', '--cache'],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)])
 
     def test_activate_volgroups(self, m_run):


### PR DESCRIPTION
vgscan --mknodes has a bug which creates block device nodes for any
entry in dmsetup table if it doesn't exist yet.  This breaks the
assumption that /dev/mapper entries are symlinks created by udev.
Until upstream RHBZ: #1828617 is resolved do not use --mknodes.