### PR TITLE
include imsm containers in "raids"

### DIFF
--- a/probert/raid.py
+++ b/probert/raid.py
@@ -121,6 +121,9 @@ def probe(context=None, report=False):
         if 'MD_NAME' in device or device.get('MD_METADATA') == 'imsm':
             devices, spares = get_mdadm_array_members(devname, device)
             cfg = dict(device)
+            if device.get('MD_METADATA') == 'imsm':
+                devices = devices + spares
+                spares = []
             cfg.update({'raidlevel': device['MD_LEVEL'],
                         'devices': devices,
                         'spare_devices': spares})

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -19,6 +19,7 @@ import subprocess
 import pyudev
 
 from probert.utils import (
+    read_sys_block_size_bytes,
     sane_block_devices,
     )
 
@@ -127,14 +128,20 @@ def probe(context=None, report=False):
                 # it may require parsing --examine output :(
                 devices = devices + spares
                 spares = []
-            cfg.update({'raidlevel': device['MD_LEVEL'],
-                        'devices': devices,
-                        'spare_devices': spares})
+            cfg.update({
+                'raidlevel': device['MD_LEVEL'],
+                'devices': devices,
+                'spare_devices': spares,
+                'size': str(read_sys_block_size_bytes(devname)),
+                })
             raids[devname] = cfg
         elif 'MD_CONTAINER' in device:
             cfg = dict(device)
-            cfg.update({'raidlevel': device['MD_LEVEL'],
-                        'container': device['MD_CONTAINER']})
+            cfg.update({
+                'raidlevel': device['MD_LEVEL'],
+                'container': device['MD_CONTAINER'],
+                'size': str(read_sys_block_size_bytes(devname)),
+                })
             raids[devname] = cfg
 
     return raids

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -123,9 +123,14 @@ def probe(context=None, report=False):
             devices, spares = get_mdadm_array_members(devname, device)
             cfg = dict(device)
             if device.get('MD_METADATA') == 'imsm':
-                # All disks in a imsm container show up as spares in --detail
-                # output. I don't know how to detect an actual spare drive --
-                # it may require parsing --examine output :(
+                # All disks in a imsm container show up as spares, in some
+                # sense because they are not "used" by the container (there is
+                # a concept of a spare drive in a container -- where there is a
+                # drive in the container that is not part of a volume/subarray
+                # within it -- but this is a fairly ephemeral concept which
+                # doesn't survive a reboot, so we don't account for that
+                # here). We don't care about that though and just record all
+                # component disks as active.
                 devices = devices + spares
                 spares = []
             cfg.update({

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -122,6 +122,9 @@ def probe(context=None, report=False):
             devices, spares = get_mdadm_array_members(devname, device)
             cfg = dict(device)
             if device.get('MD_METADATA') == 'imsm':
+                # All disks in a imsm container show up as spares in --detail
+                # output. I don't know how to detect an actual spare drive --
+                # it may require parsing --examine output :(
                 devices = devices + spares
                 spares = []
             cfg.update({'raidlevel': device['MD_LEVEL'],


### PR DESCRIPTION
Example output:

```json
ubuntu@201903-26908-Pearl-VROC:~/probert$ PYTHONPATH=. ./bin/probert --storage | jq .storage.raid
{
  "/dev/md125": {
    "DEVLINKS": "/dev/md/subvol_0 /dev/disk/by-id/md-uuid-249587ce:98f591fa:7effa7d1:4639841a",
    "DEVNAME": "/dev/md125",
    "DEVPATH": "/devices/virtual/block/md125",
    "DEVTYPE": "disk",
    "MAJOR": "9",
    "MD_CONTAINER": "/dev/md/imsm0",
    "MD_DEVICES": "2",
    "MD_DEVICE_ev_nvme0n1_DEV": "/dev/nvme0n1",
    "MD_DEVICE_ev_nvme0n1_ROLE": "0",
    "MD_DEVICE_ev_nvme1n1_DEV": "/dev/nvme1n1",
    "MD_DEVICE_ev_nvme1n1_ROLE": "1",
    "MD_DEVNAME": "subvol_0",
    "MD_LEVEL": "raid0",
    "MD_MEMBER": "0",
    "MD_UUID": "249587ce:98f591fa:7effa7d1:4639841a",
    "MINOR": "125",
    "SUBSYSTEM": "block",
    "TAGS": ":systemd:",
    "UDISKS_MD_CONTAINER": "/dev/md/imsm0",
    "UDISKS_MD_DEVICES": "2",
    "UDISKS_MD_DEVICE_ev_nvme0n1_DEV": "/dev/nvme0n1",
    "UDISKS_MD_DEVICE_ev_nvme0n1_ROLE": "0",
    "UDISKS_MD_DEVICE_ev_nvme1n1_DEV": "/dev/nvme1n1",
    "UDISKS_MD_DEVICE_ev_nvme1n1_ROLE": "1",
    "UDISKS_MD_DEVNAME": "subvol_0",
    "UDISKS_MD_LEVEL": "raid0",
    "UDISKS_MD_MEMBER": "0",
    "UDISKS_MD_UUID": "249587ce:98f591fa:7effa7d1:4639841a",
    "USEC_INITIALIZED": "8214155",
    "container": "/dev/md/imsm0",
    "raidlevel": "raid0",
    "size": "214748364800"
  },
  "/dev/md126": {
    "DEVLINKS": "/dev/disk/by-id/md-uuid-e856c50b:6a264cbf:d8167402:0ca51807 /dev/md/Volume0_ddd_dd_0 /dev/disk/by-uuid/cbae1d27-6a09-43c5-b5e5-3acc3c667423",
    "DEVNAME": "/dev/md126",
    "DEVPATH": "/devices/virtual/block/md126",
    "DEVTYPE": "disk",
    "ID_FS_TYPE": "ext4",
    "ID_FS_USAGE": "filesystem",
    "ID_FS_UUID": "cbae1d27-6a09-43c5-b5e5-3acc3c667423",
    "ID_FS_UUID_ENC": "cbae1d27-6a09-43c5-b5e5-3acc3c667423",
    "ID_FS_VERSION": "1.0",
    "MAJOR": "9",
    "MD_CONTAINER": "/dev/md/imsm0",
    "MD_DEVICES": "2",
    "MD_DEVICE_ev_nvme0n1_DEV": "/dev/nvme0n1",
    "MD_DEVICE_ev_nvme0n1_ROLE": "0",
    "MD_DEVICE_ev_nvme1n1_DEV": "/dev/nvme1n1",
    "MD_DEVICE_ev_nvme1n1_ROLE": "1",
    "MD_DEVNAME": "Volume0_ddd_dd_0",
    "MD_LEVEL": "raid1",
    "MD_MEMBER": "1",
    "MD_MON_THIS": "../md127",
    "MD_UUID": "e856c50b:6a264cbf:d8167402:0ca51807",
    "MINOR": "126",
    "SUBSYSTEM": "block",
    "SYSTEMD_WANTS": "mdmonitor.service mdmon@md127.service",
    "TAGS": ":systemd:",
    "UDISKS_MD_CONTAINER": "/dev/md/imsm0",
    "UDISKS_MD_DEVICES": "2",
    "UDISKS_MD_DEVICE_ev_nvme0n1_DEV": "/dev/nvme0n1",
    "UDISKS_MD_DEVICE_ev_nvme0n1_ROLE": "0",
    "UDISKS_MD_DEVICE_ev_nvme1n1_DEV": "/dev/nvme1n1",
    "UDISKS_MD_DEVICE_ev_nvme1n1_ROLE": "1",
    "UDISKS_MD_DEVNAME": "Volume0_ddd_dd_0",
    "UDISKS_MD_LEVEL": "raid1",
    "UDISKS_MD_MEMBER": "1",
    "UDISKS_MD_UUID": "e856c50b:6a264cbf:d8167402:0ca51807",
    "USEC_INITIALIZED": "8022090",
    "container": "/dev/md/imsm0",
    "raidlevel": "raid1",
    "size": "141238992896"
  },
  "/dev/md127": {
    "DEVLINKS": "/dev/disk/by-id/md-uuid-565e328b:b32b572e:6c389fe1:404f42a9 /dev/md/imsm0",
    "DEVNAME": "/dev/md127",
    "DEVPATH": "/devices/virtual/block/md127",
    "DEVTYPE": "disk",
    "MAJOR": "9",
    "MD_DEVICES": "2",
    "MD_DEVICE_ev_nvme0n1_DEV": "/dev/nvme0n1",
    "MD_DEVICE_ev_nvme0n1_ROLE": "spare",
    "MD_DEVICE_ev_nvme1n1_DEV": "/dev/nvme1n1",
    "MD_DEVICE_ev_nvme1n1_ROLE": "spare",
    "MD_DEVNAME": "imsm0",
    "MD_LEVEL": "container",
    "MD_METADATA": "imsm",
    "MD_UUID": "565e328b:b32b572e:6c389fe1:404f42a9",
    "MINOR": "127",
    "SUBSYSTEM": "block",
    "SYSTEMD_READY": "0",
    "TAGS": ":systemd:",
    "UDISKS_MD_DEVICES": "2",
    "UDISKS_MD_DEVICE_ev_nvme0n1_DEV": "/dev/nvme0n1",
    "UDISKS_MD_DEVICE_ev_nvme0n1_ROLE": "spare",
    "UDISKS_MD_DEVICE_ev_nvme1n1_DEV": "/dev/nvme1n1",
    "UDISKS_MD_DEVICE_ev_nvme1n1_ROLE": "spare",
    "UDISKS_MD_DEVNAME": "imsm0",
    "UDISKS_MD_LEVEL": "container",
    "UDISKS_MD_METADATA": "imsm",
    "UDISKS_MD_UUID": "565e328b:b32b572e:6c389fe1:404f42a9",
    "USEC_INITIALIZED": "8000457",
    "devices": [
      "/dev/nvme0n1",
      "/dev/nvme1n1"
    ],
    "raidlevel": "container",
    "size": "0",
    "spare_devices": []
  }
}
```

It's not perfect -- see the whinge about how to identify spares in an imsm array -- but it's a start.