### PR TITLE
os-prober: fix infinite loop

### DIFF
--- a/probert/os.py
+++ b/probert/os.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import functools
 import logging
 import re
 import subprocess
@@ -57,15 +58,22 @@ def _parse_osprober(lines):
     return ret
 
 
-def probe(context=None):
-    """Capture detected OSes. Indexed by partition as decided by os-prober."""
+@functools.lru_cache
+def _run_os_prober():
     cmd = ['os-prober']
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 universal_newlines=True, check=True)
-        output = result.stdout or ''
+        return result.stdout or ''
     except subprocess.CalledProcessError as cpe:
         log.exception('Failed to probe OSes\n%s', cpe.stderr or '')
+        return None
+
+
+def probe(context=None):
+    """Capture detected OSes. Indexed by partition as decided by os-prober."""
+    output = _run_os_prober()
+    if not output:
         return {}
     return _parse_osprober(output.splitlines())

--- a/probert/tests/test_os.py
+++ b/probert/tests/test_os.py
@@ -17,10 +17,13 @@ import subprocess
 from unittest import TestCase
 from unittest.mock import patch
 
-from probert.os import probe, _parse_osprober
+from probert.os import probe, _parse_osprober, _run_os_prober
 
 
 class TestOsProber(TestCase):
+    def tearDown(self):
+        _run_os_prober.cache_clear()
+
     def test_empty(self):
         self.assertEqual({}, _parse_osprober([]))
 
@@ -144,3 +147,10 @@ class TestOsProber(TestCase):
     def test_osprober_fail(self, run):
         run.side_effect = subprocess.CalledProcessError(1, 'cmd')
         self.assertEqual({}, probe())
+
+    @patch('probert.os.subprocess.run')
+    def test_run_once(self, run):
+        run.return_value.stdout = ''
+        self.assertEqual({}, probe())
+        self.assertEqual({}, probe())
+        run.assert_called_once()


### PR DESCRIPTION
Subiquity calls Probert, which runs os-prober, which causes udev events,
which Subiquity notices, which causes another Probert invocation ...

Adjust Probert to run os-prober once.