### PR TITLE
raid: find a RAID's members via sysfs not udev

### DIFF
--- a/probert/raid.py
+++ b/probert/raid.py
@@ -13,7 +13,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import glob
 import logging
+import os
 import subprocess
 
 import pyudev
@@ -41,64 +43,25 @@ def mdadm_assemble(scan=True, ignore_errors=True):
     return
 
 
-def get_mdadm_array_spares(md_device, detail):
+def get_mdadm_array_members(device):
+    '''extract array devices and spares from sysfs.
 
-    def role_key_to_dev(rolekey):
-        # MD_DEVICE_dev_dm_5_ROLE=spare -> MD_DEVICE_dev_dm_5_DEV
-        devname_mangled = rolekey.split('MD_DEVICE_')[1].split('_ROLE')[0]
-        return 'MD_DEVICE_%s_DEV' % devname_mangled
-
-    def keymatch(key, data, role):
-        prefix = key.startswith('MD_DEVICE_')
-        suffix = key.endswith('_ROLE')
-        matches = data.get(key) == role
-        return (prefix and suffix and matches)
-
-    def get_dev_from_key(key, data):
-        return data.get(role_key_to_dev(key))
-
-    return [get_dev_from_key(key, detail) for key in detail.keys()
-            if keymatch(key, detail, 'spare')]
-
-
-def get_mdadm_array_members(md_device, detail):
-    ''' extract array devices and spares from mdadm --detail --export output
-
-    MD_LEVEL=raid5
-    MD_DEVICES=3
-    MD_METADATA=1.2
-    MD_UUID=7fe1895e:34dcb6dc:d1bcbb9c:f3e05134
-    MD_NAME=s1lp6:raid5-2406-2407-2408-2409
-    MD_DEVICE_ev_dm_5_ROLE=spare
-    MD_DEVICE_ev_dm_5_DEV=/dev/dm-5
-    MD_DEVICE_ev_dm_3_ROLE=1
-    MD_DEVICE_ev_dm_3_DEV=/dev/dm-3
-    MD_DEVICE_ev_dm_4_ROLE=2
-    MD_DEVICE_ev_dm_4_DEV=/dev/dm-4
-    MD_DEVICE_ev_dm_2_ROLE=0
-    MD_DEVICE_ev_dm_2_DEV=/dev/dm-2
-
-    returns (['/dev/dm2', '/dev/dm-3', '/dev/dm-4'], ['/dev/dm-5'])
+    See https://docs.kernel.org/admin-guide/md.html#md-devices-in-sysfs
+    for hints.
     '''
-    md_device_keys = [key for key in detail.keys()
-                      if key.startswith('MD_DEVICE_') and key.endswith('_DEV')]
-    spares = sorted(get_mdadm_array_spares(md_device, detail))
-    devices = sorted([detail[key] for key in md_device_keys
-                      if detail[key] not in spares])
+    devices = []
+    spares = []
+    block_links = glob.glob(os.path.join(device.sys_path, 'md/dev-*/block'))
+    for block_link in block_links:
+        member_devname = '/dev/' + os.path.basename(os.readlink(block_link))
+        state_file = os.path.join(os.path.dirname(block_link), 'state')
+        with open(state_file) as fp:
+            state = fp.read().strip()
+        if state == 'spare':
+            spares.append(member_devname)
+        else:
+            devices.append(member_devname)
     return (devices, spares)
-
-
-def extract_mdadm_raid_name(conf):
-    ''' return the raid array name, removing homehost if present.
-
-    MD_NAME=s1lp6:raid5-2406-2407-2408-2409
-
-    returns 'raid5-2406-2407-2408-2409'
-    '''
-    raid_name = conf.get('MD_NAME')
-    if ':' in raid_name:
-        _, raid_name = raid_name.split(':')
-    return raid_name
 
 
 def probe(context=None, report=False):
@@ -116,11 +79,19 @@ def probe(context=None, report=False):
 
     raids = {}
     for device in sane_block_devices(context):
-        if device.get('DEVTYPE') != 'disk':
+        if not os.path.exists(os.path.join(device.sys_path, 'md')):
             continue
         devname = device['DEVNAME']
-        if 'MD_NAME' in device or device.get('MD_METADATA') == 'imsm':
-            devices, spares = get_mdadm_array_members(devname, device)
+        if 'MD_CONTAINER' in device:
+            cfg = dict(device)
+            cfg.update({
+                'raidlevel': device['MD_LEVEL'],
+                'container': device['MD_CONTAINER'],
+                'size': str(read_sys_block_size_bytes(devname)),
+                })
+            raids[devname] = cfg
+        else:
+            devices, spares = get_mdadm_array_members(device)
             cfg = dict(device)
             if device.get('MD_METADATA') == 'imsm':
                 # All disks in a imsm container show up as spares, in some
@@ -137,14 +108,6 @@ def probe(context=None, report=False):
                 'raidlevel': device['MD_LEVEL'],
                 'devices': devices,
                 'spare_devices': spares,
-                'size': str(read_sys_block_size_bytes(devname)),
-                })
-            raids[devname] = cfg
-        elif 'MD_CONTAINER' in device:
-            cfg = dict(device)
-            cfg.update({
-                'raidlevel': device['MD_LEVEL'],
-                'container': device['MD_CONTAINER'],
                 'size': str(read_sys_block_size_bytes(devname)),
                 })
             raids[devname] = cfg


### PR DESCRIPTION
mdadm changed in upstream commit
1a52f1fc0266d438c996789d4addbfac999a6139 to not record array membership
in udev (to avoid problems with huge RAID arrays). So go looking in
sysfs instead.

Includes some other cleanups I couldn't resist while I was there.