### PR TITLE
PY_SSIZE_T_CLEAN & python 3.10 compatibility

### DIFF
--- a/probert/_nl80211module.c
+++ b/probert/_nl80211module.c
@@ -418,7 +418,7 @@ static void extract_ssid(struct nlattr *data, struct scan_handler_params *p)
 		return;
 	}
 	char *ie = nla_data(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
-	int ie_len = nla_len(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
+	size_t ie_len = nla_len(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
 	char *ssid = nl80211_get_ie(ie, ie_len, 0);
 	ssize_t ssid_len = (ssize_t)ssid[1];
 	PyObject* v = Py_BuildValue("(y#s)", ssid + 2, ssid_len, cstatus);

--- a/probert/_nl80211module.c
+++ b/probert/_nl80211module.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <ctype.h>
 #include <errno.h>
@@ -419,7 +420,7 @@ static void extract_ssid(struct nlattr *data, struct scan_handler_params *p)
 	char *ie = nla_data(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
 	int ie_len = nla_len(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
 	char *ssid = nl80211_get_ie(ie, ie_len, 0);
-	int ssid_len = ssid[1];
+	ssize_t ssid_len = (ssize_t)ssid[1];
 	PyObject* v = Py_BuildValue("(y#s)", ssid + 2, ssid_len, cstatus);
 	if (v == NULL) {
 		Py_CLEAR(p->ssid_list);

--- a/probert/_rtnetlinkmodule.c
+++ b/probert/_rtnetlinkmodule.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <ctype.h>
 #include <errno.h>


### PR DESCRIPTION
Implement PY_SSIZE_T_CLEAN.  It requires that, instead of using int for various
buffer lengths, that we instead use ssize_t.  While there are several calls to
PyArg_ParseTuple and Py_BuildValue family functions, only this one seems to be
passing around a length value.

Verified by running against Jammy with python 3.10, and console-conf in
dry-run, on hardware that has a wireless network interface.

(LP: #1964571)