### PR TITLE
storage: exclude os from the default probe set

### DIFF
--- a/probert/os.py
+++ b/probert/os.py
@@ -17,6 +17,7 @@
 import functools
 import logging
 import re
+import shutil
 import subprocess
 
 log = logging.getLogger('probert.os')
@@ -60,9 +61,14 @@ def _parse_osprober(lines):
 
 @functools.lru_cache(maxsize=1)
 def _run_os_prober():
-    cmd = ['os-prober']
+    for cmd in 'subiquity.os-prober', 'os-prober':
+        if shutil.which(cmd):
+            break
+    else:
+        log.error('failed to locate os-prober')
+        return None
     try:
-        result = subprocess.run(cmd, stdout=subprocess.PIPE,
+        result = subprocess.run([cmd], stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 universal_newlines=True, check=True)
         return result.stdout or ''


### PR DESCRIPTION
Exclude 'os' from the default storage probes.
Add a 'defaults' keyword, which can be used in a set with 'os' to get both the
defaults and the 'os' result.