### PR TITLE
Do not recognize partitions of RAIDs as full RAIDs

### DIFF
--- a/probert/raid.py
+++ b/probert/raid.py
@@ -112,6 +112,8 @@ def probe(context=None, report=False):
 
     raids = {}
     for device in sane_block_devices(context):
+        if device.get('DEVTYPE') != 'disk':
+            continue
         devname = device['DEVNAME']
         if not os.path.basename(devname).startswith('md'):
             continue


### PR DESCRIPTION
For https://bugs.launchpad.net/ubuntu/+source/curtin/+bug/1970116
Cherry-pick 79b2c34b4337ce7d11c771f3cb3868b90cae0c3f