### PR TITLE
use sane_block_devices when looking for dasds

### DIFF
--- a/probert/bcache.py
+++ b/probert/bcache.py
@@ -17,6 +17,9 @@ import logging
 import os
 import subprocess
 
+from probert.utils import sane_block_devices
+
+
 log = logging.getLogger('probert.bcache')
 
 
@@ -113,7 +116,7 @@ def probe(context=None):
     if not context:
         return bcache
 
-    for device in context.list_devices(subsystem='block'):
+    for device in sane_block_devices(context):
         if is_bcache_device(device):
             devpath = device['DEVNAME']
             sb = superblock_asdict(devpath)

--- a/probert/dasd.py
+++ b/probert/dasd.py
@@ -20,6 +20,9 @@ import pyudev
 import re
 import subprocess
 
+from probert.utils import sane_block_devices
+
+
 log = logging.getLogger('probert.dasd')
 
 
@@ -145,7 +148,7 @@ def probe(context=None):
 
     log.debug("found MAJOR for virtblk: %s", virtio_major)
 
-    for device in context.list_devices(subsystem='block'):
+    for device in sane_block_devices(context):
         # ignore partitions
         if 'PARTN' in device:
             continue


### PR DESCRIPTION
For https://bugs.launchpad.net/subiquity/+bug/1972834.