### PR TITLE
filesystem: get_swap_size for dm-crypt luks swap devices

### DIFF
--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -150,10 +150,17 @@ def get_ntfs_sizing(device):
 
 
 def get_swap_sizing(device):
-    return {
-        'SIZE': device['ID_PART_ENTRY_SIZE'] * 512,
-        'ESTIMATED_MIN_SIZE': 0
-    }
+    if 'ID_PART_ENTRY_SIZE' in device:
+        size = device['ID_PART_ENTRY_SIZE'] * 512
+    else:
+        size = int(device.get('attrs', {}).get('size', 0))
+    if not size:
+        log.debug(
+            'swap volume size not found. Neither ID_PART_ENTRY_SIZE nor'
+            ' attrs:size present'
+        )
+        return None
+    return {'SIZE': size, 'ESTIMATED_MIN_SIZE': 0}
 
 
 sizing_tools = {

--- a/probert/tests/test_filesystem.py
+++ b/probert/tests/test_filesystem.py
@@ -16,6 +16,7 @@
 import random
 import string
 
+import pytest
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -37,6 +38,31 @@ def read_file(filename):
 def random_string(length=8):
     return ''.join(
         random.choice(string.ascii_lowercase) for _ in range(length))
+
+
+class TestGetSwapSizing:
+    @pytest.mark.parametrize(
+        "device,expected",
+        (
+            (
+                {"ID_PART_ENTRY_SIZE": 2},
+                {"SIZE": 1024, "ESTIMATED_MIN_SIZE": 0}
+            ),
+            (
+                {
+                    "DEVNAME": "/dev/dm-1",
+                    "DEVTYPE": "disk",
+                    "DM_VG_NAME": "vg1",
+                    "attrs": {
+                        "size": "1073741824",
+                    },
+                },
+                {"SIZE": 1073741824, "ESTIMATED_MIN_SIZE": 0},
+            ),
+        ),
+    )
+    def test_expected_output(self, device, expected):
+        assert expected == get_swap_sizing(device)
 
 
 class TestFilesystem(TestCase):


### PR DESCRIPTION
dm-crypt swap devices do not present ID_PART_ENTRY_SIZE values.
When ID_PART_ENTRY_SIZE is absent, fallback to the bytes value
under attrs:size. When both fields are absent, log a debug message
and return None for swap size.