### PR TITLE
storage: skip partitions on device we are skipping

### DIFF
--- a/probert/tests/test_storage.py
+++ b/probert/tests/test_storage.py
@@ -2,8 +2,38 @@ import testtools
 from unittest.mock import Mock
 import json
 
-from probert.storage import Storage, StorageInfo
+from probert.storage import Storage, StorageInfo, interesting_storage_devs
 from probert.tests.fakes import FAKE_PROBE_ALL_JSON
+
+from parameterized import parameterized
+
+
+class ProbertTestInterestingDevs(testtools.TestCase):
+    @parameterized.expand([
+        ['1', 0],
+        ['2', 1],
+        ['7', 0],
+    ])
+    def test_major_filtering(self, major, expected):
+        context = Mock()
+        context.list_devices.return_value = [{'MAJOR': major}]
+
+        actual = len(list(interesting_storage_devs(context)))
+        self.assertEqual(expected, actual)
+
+    @parameterized.expand([
+        ['7:0', 0],
+        ['8:0', 1],
+    ])
+    def test_parent_major_filtering(self, parent_majmin, expected):
+        context = Mock()
+        context.list_devices.return_value = [{
+            'MAJOR': '259',
+            'ID_PART_ENTRY_DISK': parent_majmin
+        }]
+
+        actual = len(list(interesting_storage_devs(context)))
+        self.assertEqual(expected, actual)
 
 
 class ProbertTestStorage(testtools.TestCase):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 flake8
 mock
+parameterized
 pytest
 pytest-cov
 testtools


### PR DESCRIPTION
Subiquity installs are now failing when it tries to hand the probe results to curtin and they contain partitions that are on a loopback device.  Curtin tries to associate this partition to a disk, and that disk doesn't exist because it has been filtered from the results.

So also filter those partitions.