### PR TITLE
storage: handle inactive arrays, which don't have a RAID level

### DIFF
--- a/probert/raid.py
+++ b/probert/raid.py
@@ -147,10 +147,10 @@ def probe(context=None, report=False, **kw):
                 'spare_devices': spares,
                 'size': str(read_sys_block_size_bytes(devname)),
                 })
-                if 'MD_LEVEL' in device:
-                    cfg.update({
-                        'raidlevel': device['MD_LEVEL'],
-                    })
+            if 'MD_LEVEL' in device:
+                cfg.update({
+                    'raidlevel': device['MD_LEVEL'],
+                })
             raids[devname] = cfg
 
     return raids

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -120,9 +120,12 @@ def probe(context=None, report=False, **kw):
         if 'MD_CONTAINER' in device:
             cfg = dict(device)
             cfg.update({
-                'raidlevel': device['MD_LEVEL'],
                 'container': device['MD_CONTAINER'],
                 'size': str(read_sys_block_size_bytes(devname)),
+                })
+            if 'MD_LEVEL' in device:
+                cfg.update({
+                    'raidlevel': device['MD_LEVEL'],
                 })
             raids[devname] = cfg
         else:
@@ -140,11 +143,14 @@ def probe(context=None, report=False, **kw):
                 devices = devices + spares
                 spares = []
             cfg.update({
-                'raidlevel': device['MD_LEVEL'],
                 'devices': devices,
                 'spare_devices': spares,
                 'size': str(read_sys_block_size_bytes(devname)),
                 })
+                if 'MD_LEVEL' in device:
+                    cfg.update({
+                        'raidlevel': device['MD_LEVEL'],
+                    })
             raids[devname] = cfg
 
     return raids


### PR DESCRIPTION
In probing arrays, if the array is inactive then udev does not report an MD_LEVEL value for the array.  This was causing a KeyError when probe() tried to add the raidlevel key for the device.  This change checks see if MD_LEVEL exists before it tries to access it.