### PR TITLE
swap: fix calculation of swap size

### DIFF
--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -151,7 +151,7 @@ def get_ntfs_sizing(device):
 
 def get_swap_sizing(device):
     if 'ID_PART_ENTRY_SIZE' in device:
-        size = device['ID_PART_ENTRY_SIZE'] * 512
+        size = int(device['ID_PART_ENTRY_SIZE']) * 512
     else:
         size = int(device.get('attrs', {}).get('size', 0))
     if not size:

--- a/probert/tests/test_filesystem.py
+++ b/probert/tests/test_filesystem.py
@@ -138,6 +138,11 @@ You might resize at 25000000 bytes or 25 MB (freeing 75 MB).
         expected = {'SIZE': 1024, 'ESTIMATED_MIN_SIZE': 0}
         self.assertEqual(expected, get_swap_sizing(device))
 
+    def test_swap_sizing_as_string(self):
+        device = {'ID_PART_ENTRY_SIZE': "2"}
+        expected = {'SIZE': 1024, 'ESTIMATED_MIN_SIZE': 0}
+        self.assertEqual(expected, get_swap_sizing(device))
+
     def test_get_device_filesystem_no_sizing(self):
         data = {'ID_FS_FOO': 'bar'}
         self.device.items = lambda: data.items()


### PR DESCRIPTION
When `ID_PART_ENTRY_SIZE` is defined, the size of the swap is defined as `512 * ID_PART_ENTRY_SIZE`.
However, when the value is given as a string, the result is ... 512 times the string ; which is hardly what we expect.

Fixed by converting the string to an integer before applying the multiplication.

I noticed the issue when troubleshooting https://bugs.launchpad.net/subiquity/+bug/2002413