### PR TITLE
Fix stderr logging of resize tools

### DIFF
--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -14,37 +14,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
 import re
 import shutil
-import subprocess
 
 import pyudev
 
-from probert.utils import sane_block_devices
+from probert.utils import (
+    run,
+    sane_block_devices,
+)
 
 log = logging.getLogger('probert.filesystems')
-
-
-def _clean_env(env):
-    if env is None:
-        env = os.environ.copy()
-    else:
-        env = env.copy()
-    env['LC_ALL'] = 'C'
-    return env
-
-
-def run(cmdarr, env=None, **kw):
-    env = _clean_env(env)
-    try:
-        return subprocess.check_output(cmdarr, universal_newlines=True,
-                                       env=env, **kw)
-    except subprocess.CalledProcessError as cpe:
-        if cpe.stderr:
-            log.debug('stderr: %s', cpe.stderr)
-        log.exception(cpe)
-        return None
 
 
 def get_dumpe2fs_info(path):


### PR DESCRIPTION
enhance the command runner run() with the following properties:
1) stdout/stderr/return code always logged, pass or fail
2) clear output distinction - no ambiguity between other logging and
   command output, and a discernable difference between no output on
   a channel versues empty lines
3) like before, returns stdout or None for pass/fail

I see this as something of a template for what good command output logging could look like, so I specifically want nitpicky type feedback before I copy it to other places.

Attached is an example of pass and fail output logging using this, as captured in Subiquity.

[probert-log-updates.log](https://github.com/canonical/probert/files/11022686/probert-log-updates.log)
