### PR TITLE
filesystem-sizing: disable progress indicator on ntfsresize

### DIFF
--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -95,6 +95,7 @@ def get_ntfs_sizing(device):
     cmd = [ntfsresize,
            '--no-action',
            '--force',  # needed post-resize, which otherwise demands a CHKDSK
+           '--no-progress-bar',
            '--info', path]
     out = run(cmd)
     if out is None:


### PR DESCRIPTION
By default, ntfsresize shows a progress indicator even if the output is not a terminal. This leads to very verbose logging, as in:

```
2023-04-14 10:29:25,542 DEBUG probert.utils:49   0.03 percent completed
2023-04-14 10:29:25,542 DEBUG probert.utils:49   0.04 percent completed
2023-04-14 10:29:25,543 DEBUG probert.utils:49   0.06 percent completed
2023-04-14 10:29:25,543 DEBUG probert.utils:49   0.07 percent completed
2023-04-14 10:29:25,543 DEBUG probert.utils:49   0.09 percent completed
2023-04-14 10:29:25,543 DEBUG probert.utils:49   0.10 percent completed
2023-04-14 10:29:25,544 DEBUG probert.utils:49   0.12 percent completed
2023-04-14 10:29:25,544 DEBUG probert.utils:49   0.13 percent completed
2023-04-14 10:29:25,544 DEBUG probert.utils:49   0.15 percent completed
2023-04-14 10:29:25,544 DEBUG probert.utils:49   0.16 percent completed
2023-04-14 10:29:25,545 DEBUG probert.utils:49   0.18 percent completed
2023-04-14 10:29:25,545 DEBUG probert.utils:49   0.19 percent completed
```

Disabled by passing the `--no-progress-bar` option to `ntfsresize`.