### PR TITLE
tests: use unittest instead of testtools and mock

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,11 +11,9 @@ Build-Depends: debhelper-compat (= 13),
                python3-coverage,
                python3-flake8,
                python3-jsonschema,
-               python3-mock,
                python3-nose,
                python3-pyudev,
                python3-setuptools,
-               python3-testtools
 Standards-Version: 4.5.0
 Homepage: https://github.com/canonical/probert
 Vcs-Browser: https://github.com/canonical/probert

--- a/probert/tests/helpers.py
+++ b/probert/tests/helpers.py
@@ -16,9 +16,9 @@
 import contextlib
 import imp
 import importlib
-import mock
 import random
 import string
+import unittest
 
 
 def builtin_module_name():
@@ -38,10 +38,10 @@ def builtin_module_name():
 def simple_mocked_open(content=None):
     if not content:
         content = ''
-    m_open = mock.mock_open(read_data=content)
+    m_open = unittest.mock.mock_open(read_data=content)
     mod_name = builtin_module_name()
     m_patch = '{}.open'.format(mod_name)
-    with mock.patch(m_patch, m_open, create=True):
+    with unittest.mock.patch(m_patch, m_open, create=True):
         yield m_open
 
 

--- a/probert/tests/test_dasd.py
+++ b/probert/tests/test_dasd.py
@@ -1,6 +1,6 @@
-import mock
 import subprocess
-import testtools
+import unittest
+from unittest import mock
 
 from probert import dasd
 from probert.tests import fakes
@@ -39,7 +39,7 @@ expected_probe_data = {
     }
 
 
-class TestDasd(testtools.TestCase):
+class TestDasd(unittest.TestCase):
 
     def _load_test_data(self, data_fname):
         testfile = fakes.TEST_DATA + '/' + data_fname

--- a/probert/tests/test_lvm.py
+++ b/probert/tests/test_lvm.py
@@ -1,8 +1,8 @@
 import json
-import mock
 import subprocess
-import testtools
 import textwrap
+import unittest
+from unittest import mock
 
 from probert import lvm
 from probert.tests.helpers import random_string
@@ -67,7 +67,7 @@ VGS_REPORT_DUPES = 2 * VGS_REPORT
 
 
 @mock.patch('probert.lvm.subprocess.run')
-class TestLvm(testtools.TestCase):
+class TestLvm(unittest.TestCase):
 
     def test__lvm_report_returns_empty_list_on_err(self, m_run):
         m_run.side_effect = subprocess.CalledProcessError(

--- a/probert/tests/test_multipath.py
+++ b/probert/tests/test_multipath.py
@@ -1,6 +1,6 @@
-import mock
 import subprocess
-import testtools
+import unittest
+from unittest import mock
 
 from probert import multipath
 from probert.tests.helpers import random_string
@@ -8,7 +8,7 @@ from probert.tests.helpers import random_string
 MP_SEP = multipath.MP_SEP
 
 
-class TestMultipath(testtools.TestCase):
+class TestMultipath(unittest.TestCase):
 
     @mock.patch('probert.multipath.subprocess.run')
     def test_multipath_show_paths(self, m_run):

--- a/probert/tests/test_prober.py
+++ b/probert/tests/test_prober.py
@@ -1,4 +1,4 @@
-import testtools
+import unittest
 from unittest.mock import patch
 
 from probert.prober import Prober
@@ -6,7 +6,7 @@ from probert.storage import Storage
 from probert.network import NetworkProber
 
 
-class ProbertTestProber(testtools.TestCase):
+class ProbertTestProber(unittest.TestCase):
 
     def test_prober_init(self):
         p = Prober()

--- a/probert/tests/test_storage.py
+++ b/probert/tests/test_storage.py
@@ -1,4 +1,4 @@
-import testtools
+import unittest
 from unittest.mock import Mock
 import json
 
@@ -8,7 +8,7 @@ from probert.tests.fakes import FAKE_PROBE_ALL_JSON
 from parameterized import parameterized
 
 
-class ProbertTestInterestingDevs(testtools.TestCase):
+class ProbertTestInterestingDevs(unittest.TestCase):
     @parameterized.expand([
         ['1', 0],
         ['2', 1],
@@ -36,7 +36,7 @@ class ProbertTestInterestingDevs(testtools.TestCase):
         self.assertEqual(expected, actual)
 
 
-class ProbertTestStorage(testtools.TestCase):
+class ProbertTestStorage(unittest.TestCase):
     def setUp(self):
         super(ProbertTestStorage, self).setUp()
 
@@ -47,7 +47,7 @@ class ProbertTestStorage(testtools.TestCase):
         self.assertNotEqual(None, storage)
 
 
-class ProbertTestStorageProbeSet(testtools.TestCase):
+class ProbertTestStorageProbeSet(unittest.TestCase):
     def setUp(self):
         super(ProbertTestStorageProbeSet, self).setUp()
         self.storage = Storage()
@@ -87,7 +87,7 @@ class ProbertTestStorageProbeSet(testtools.TestCase):
             v.pfunc.assert_not_called()
 
 
-class ProbertTestStorageInfo(testtools.TestCase):
+class ProbertTestStorageInfo(unittest.TestCase):
     ''' properties:
         .name = /dev/sda
         .type = disk

--- a/probert/tests/test_utils.py
+++ b/probert/tests/test_utils.py
@@ -1,17 +1,16 @@
 import contextlib
 import logging
-from mock import call
 import os
 import tempfile
-import testtools
 import textwrap
-# import unittest
+import unittest
+from unittest.mock import call
 
 from probert import utils
 from probert.tests.helpers import random_string, simple_mocked_open
 
 
-class ProbertTestUtils(testtools.TestCase):
+class ProbertTestUtils(unittest.TestCase):
     def setUp(self):
         super(ProbertTestUtils, self).setUp()
 
@@ -79,7 +78,7 @@ def create_script(content):
             os.remove(script)
 
 
-class ProbertTestRun(testtools.TestCase):
+class ProbertTestRun(unittest.TestCase):
     leader = 'DEBUG:probert.utils:'
 
     def test_run_success_no_output(self):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,4 @@
 flake8
-mock
 parameterized
 pytest
 pytest-cov
-testtools


### PR DESCRIPTION
I have prepared a branch to make probert storage asyncio-ready (and enable parallelism if desired - which makes things faster).

Sadly, testtools does not have support for something like `IsolatedAsyncioTestCase` (yet?).

Since, we're not using anything special from testtools or mock, we can safely move to using the testing tools from the standard library instead.