### PR TITLE
Move storage code to asyncio - optionally enable parallelism for probes

### DIFF
--- a/bin/probert
+++ b/bin/probert
@@ -34,6 +34,8 @@ def parse_options(argv):
                         help='Probe storage hardware.')
     parser.add_argument('--network', action='store_true',
                         help='Probe network hardware.')
+    parser.add_argument('--parallel', action='store_true',
+                        help='Run storage probes in parallel')
     return parser.parse_args(argv)
 
 
@@ -47,11 +49,11 @@ async def main():
     p = prober.Prober()
     probe_opts = [opts.network, opts.storage]
     if opts.all or not any(probe_opts):
-        await p.probe_all()
+        await p.probe_all(parallelize=opts.parallel)
     if opts.network:
         await p.probe_network()
     if opts.storage:
-        await p.probe_storage()
+        await p.probe_storage(parallelize=opts.parallel)
 
     results = p.get_results()
     print(json.dumps(results, indent=4, sort_keys=True))

--- a/bin/probert
+++ b/bin/probert
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import argparse
 import sys
 import json
@@ -36,7 +37,7 @@ def parse_options(argv):
     return parser.parse_args(argv)
 
 
-def main():
+async def main():
     opts = parse_options(sys.argv[1:])
     setup_logger()
     logger = logging.getLogger('probert')
@@ -46,15 +47,15 @@ def main():
     p = prober.Prober()
     probe_opts = [opts.network, opts.storage]
     if opts.all or not any(probe_opts):
-        p.probe_all()
+        await p.probe_all()
     if opts.network:
-        p.probe_network()
+        await p.probe_network()
     if opts.storage:
-        p.probe_storage()
+        await p.probe_storage()
 
     results = p.get_results()
     print(json.dumps(results, indent=4, sort_keys=True))
 
 
 if __name__ == '__main__':
-    main()
+    asyncio.run(main())

--- a/probert/bcache.py
+++ b/probert/bcache.py
@@ -92,7 +92,7 @@ def is_bcache_device(device):
     return device.get('ID_FS_TYPE') == 'bcache'
 
 
-def probe(context=None, **kw):
+async def probe(context=None, **kw):
     """Probe the system for bcache devices.  Bcache devices
        are registered with the kernel upon module load and when
        devices are hot/cold plugged.  There are two portions to

--- a/probert/dasd.py
+++ b/probert/dasd.py
@@ -124,7 +124,7 @@ def get_dasd_info(device):
         }
 
 
-def probe(context=None, **kw):
+async def probe(context=None, **kw):
     """Examine all dasd devices present and extract configuration attributes
 
        This data is useful for determining if the dasd device has been

--- a/probert/dmcrypt.py
+++ b/probert/dmcrypt.py
@@ -48,7 +48,7 @@ def dmsetup_info(devname):
     return info
 
 
-def probe(context=None, report=False, **kw):
+async def probe(context=None, report=False, **kw):
     """ Probing for dm_crypt devices requires running dmsetup info commands
         to collect how a particular dm-X device is composed.
     """

--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -170,7 +170,7 @@ async def get_device_filesystem(device, sizing):
     return fs_info
 
 
-async def probe(context=None, enabled_probes=None, **kw):
+async def probe(context=None, enabled_probes=None, *, parallelize=False, **kw):
     """ Capture detected filesystems found on discovered block devices.  """
     filesystems = {}
     if not context:
@@ -197,7 +197,10 @@ async def probe(context=None, enabled_probes=None, **kw):
 
     coroutines = [probe_filesystem(dev) for dev in sane_block_devices(context)]
 
-    for coroutine in coroutines:
-        await coroutine
+    if parallelize:
+        await asyncio.gather(*coroutines)
+    else:
+        for coroutine in coroutines:
+            await coroutine
 
     return filesystems

--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -21,7 +21,7 @@ import shutil
 import pyudev
 
 from probert.utils import (
-    run,
+    arun,
     sane_block_devices,
 )
 
@@ -34,8 +34,7 @@ async def get_dumpe2fs_info(path):
     if dumpe2fs is None:
         log.debug('ext volume size not found: dumpe2fs not found')
         return None
-    out = await asyncio.get_running_loop().run_in_executor(
-            None, run, [dumpe2fs, '-h', path])
+    out = await arun([dumpe2fs, '-h', path])
     if out is None:
         log.debug('ext volume size not found: dumpe2fs failure')
         return None
@@ -62,8 +61,7 @@ async def get_resize2fs_info(path):
     if resize2fs is None:
         log.debug('ext volume size not found: resize2fs not found')
         return None
-    out = await asyncio.get_running_loop().run_in_executor(
-            None, run, [resize2fs, '-P', path])
+    out = await arun([resize2fs, '-P', path])
     if out is None:
         return None
     min_blocks_matcher = re.compile(
@@ -100,7 +98,7 @@ async def get_ntfs_sizing(device):
            '--force',  # needed post-resize, which otherwise demands a CHKDSK
            '--no-progress-bar',
            '--info', path]
-    out = await asyncio.get_running_loop().run_in_executor(None, run, cmd)
+    out = await arun(cmd)
     if out is None:
         log.debug('ntfs volume size not found: ntfsresize failure')
         return None

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -170,7 +170,7 @@ def extract_lvm_volgroup(vg_name, report_data):
                       'size': size})
 
 
-def probe(context=None, **kw):
+async def probe(context=None, **kw):
     """ Probing for LVM devices requires initiating a kernel level scan
         of block devices to look for physical volumes, volume groups and
         logical volumes.  Once detected, the prober will activate any

--- a/probert/mount.py
+++ b/probert/mount.py
@@ -40,7 +40,7 @@ def findmnt(data=None):
     return mounts
 
 
-def probe(context=None, **kw):
+async def probe(context=None, **kw):
     """The probert uses the util-linux 'findmnt' command which
        dumps a JSON tree of detailed information about _all_
        mounts in the current linux system.

--- a/probert/multipath.py
+++ b/probert/multipath.py
@@ -70,7 +70,7 @@ def multipath_show_maps():
     return _extract_mpath_data(cmd, 'maps')
 
 
-def probe(context=None, **kw):
+async def probe(context=None, **kw):
     """Query the multipath daemon for multipath maps and paths.
 
        This data is useful for determining whether a specific block

--- a/probert/os.py
+++ b/probert/os.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import functools
 import logging
 import re
@@ -79,7 +80,8 @@ def _run_os_prober():
 
 async def probe(context=None, **kw):
     """Capture detected OSes. Indexed by partition as decided by os-prober."""
-    output = _run_os_prober()
+    output = await asyncio.get_running_loop().run_in_executor(
+            None, _run_os_prober)
     if not output:
         return {}
     return _parse_osprober(output.splitlines())

--- a/probert/os.py
+++ b/probert/os.py
@@ -77,7 +77,7 @@ def _run_os_prober():
         return None
 
 
-def probe(context=None, **kw):
+async def probe(context=None, **kw):
     """Capture detected OSes. Indexed by partition as decided by os-prober."""
     output = _run_os_prober()
     if not output:

--- a/probert/os.py
+++ b/probert/os.py
@@ -69,7 +69,10 @@ def _run_os_prober():
         log.error('failed to locate os-prober')
         return None
     try:
-        result = subprocess.run([cmd], stdout=subprocess.PIPE,
+        # os-prober attempts to run in a private mount namespace.
+        # However, it is not currently working.
+        # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1034485
+        result = subprocess.run(["unshare", "-m", cmd], stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 universal_newlines=True, check=True)
         return result.stdout or ''

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -18,14 +18,15 @@ class Prober():
     def __init__(self):
         self._results = {}
 
-    async def probe_all(self):
+    async def probe_all(self, *, parallelize=False):
         await self.probe_storage()
         self.probe_network()
 
-    async def probe_storage(self):
+    async def probe_storage(self, *, parallelize=False):
         from probert.storage import Storage
         self._storage = Storage()
-        self._results['storage'] = await self._storage.probe()
+        self._results['storage'] = await self._storage.probe(
+                parallelize=parallelize)
 
     def probe_network(self):
         from probert.network import NetworkProber

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -18,14 +18,14 @@ class Prober():
     def __init__(self):
         self._results = {}
 
-    def probe_all(self):
-        self.probe_storage()
+    async def probe_all(self):
+        await self.probe_storage()
         self.probe_network()
 
-    def probe_storage(self):
+    async def probe_storage(self):
         from probert.storage import Storage
         self._storage = Storage()
-        self._results['storage'] = self._storage.probe()
+        self._results['storage'] = await self._storage.probe()
 
     def probe_network(self):
         from probert.network import NetworkProber

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -97,7 +97,7 @@ def get_mdadm_array_members(md_device):
     return (sorted(actives), sorted(spares))
 
 
-def probe(context=None, report=False, **kw):
+async def probe(context=None, report=False, **kw):
     """Initiate an mdadm assemble to awaken existing MDADM devices.
        For each md block device, extract required information needed
        to describe the array for recreation or reuse as needed.

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -219,7 +219,8 @@ class Storage():
         for ptype in to_probe:
             probe = self.probe_map[ptype]
             result = await probe.pfunc(context=self.context,
-                                       enabled_probes=to_probe)
+                                       enabled_probes=to_probe,
+                                       parallelize=True)
             if result is not None:
                 probed_data[ptype] = result
 

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 from dataclasses import dataclass
 import json
 import logging
@@ -197,7 +198,7 @@ class Storage():
         return {ptype for ptype, probe in self.probe_map.items()
                 if get_all or probe.in_default_set}
 
-    async def probe(self, probe_types=None):
+    async def probe(self, probe_types=None, *, parallelize=False):
         default_probes = self._get_probe_types(False)
         all_probes = self._get_probe_types(True)
         if not probe_types:
@@ -216,13 +217,22 @@ class Storage():
             return self.results
 
         probed_data = {}
-        for ptype in to_probe:
+
+        async def run_probe(ptype):
             probe = self.probe_map[ptype]
             result = await probe.pfunc(context=self.context,
                                        enabled_probes=to_probe,
-                                       parallelize=True)
+                                       parallelize=parallelize)
             if result is not None:
                 probed_data[ptype] = result
+
+        coroutines = [run_probe(ptype) for ptype in to_probe]
+
+        if parallelize:
+            await asyncio.gather(*coroutines)
+        else:
+            for coroutine in coroutines:
+                await coroutine
 
         self.results = probed_data
         return probed_data

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -106,7 +106,7 @@ def interesting_storage_devs(context):
         yield device
 
 
-def blockdev_probe(context=None, **kw):
+async def blockdev_probe(context=None, **kw):
     """ Non-class method for extracting relevant block
         devices from pyudev.Context().
     """
@@ -154,7 +154,7 @@ class Probe:
     in_default_set: bool = True
 
 
-def null_probe(context=None, **kw):
+async def null_probe(context=None, **kw):
     """Some probe types are flags that change the behavior of other probes.
        These flag probes do nothing on their own."""
     return None
@@ -197,7 +197,7 @@ class Storage():
         return {ptype for ptype, probe in self.probe_map.items()
                 if get_all or probe.in_default_set}
 
-    def probe(self, probe_types=None):
+    async def probe(self, probe_types=None):
         default_probes = self._get_probe_types(False)
         all_probes = self._get_probe_types(True)
         if not probe_types:
@@ -218,7 +218,8 @@ class Storage():
         probed_data = {}
         for ptype in to_probe:
             probe = self.probe_map[ptype]
-            result = probe.pfunc(context=self.context, enabled_probes=to_probe)
+            result = await probe.pfunc(context=self.context,
+                                       enabled_probes=to_probe)
             if result is not None:
                 probed_data[ptype] = result
 

--- a/probert/tests/test_filesystem.py
+++ b/probert/tests/test_filesystem.py
@@ -65,7 +65,7 @@ class TestFilesystem(IsolatedAsyncioTestCase):
         self.device = Mock()
         self.device.device_node = random_string()
 
-    @patch('probert.filesystem.run')
+    @patch('probert.filesystem.arun')
     async def test_dumpe2fs_simple_output(self, run):
         run.return_value = '''
 Block count: 1234
@@ -74,13 +74,13 @@ Block size:  4000
         expected = {'block_count': 1234, 'block_size': 4000}
         self.assertEqual(expected, await get_dumpe2fs_info(self.device))
 
-    @patch('probert.filesystem.run')
+    @patch('probert.filesystem.arun')
     async def test_dumpe2fs_real_output(self, run):
         run.return_value = read_file('probert/tests/data/dumpe2fs_ext4.out')
         expected = {'block_count': 10240, 'block_size': 4096}
         self.assertEqual(expected, await get_dumpe2fs_info(self.device))
 
-    @patch('probert.filesystem.run')
+    @patch('probert.filesystem.arun')
     async def test_resize2fs(self, run):
         run.return_value = 'Estimated minimum size of the filesystem: 1371\n'
         expected = {'min_blocks': 1371}
@@ -107,19 +107,19 @@ Block size:  4000
         expected = {'SIZE': 20000 * 1000}
         self.assertEqual(expected, await get_ext_sizing(self.device))
 
-    @patch('probert.filesystem.run')
+    @patch('probert.filesystem.arun')
     async def test_ntfs_real_output(self, run):
         run.return_value = read_file('probert/tests/data/ntfsresize.out')
         expected = {'SIZE': 41939456, 'ESTIMATED_MIN_SIZE': 2613248}
         self.assertEqual(expected, await get_ntfs_sizing(self.device))
 
-    @patch('probert.filesystem.run')
+    @patch('probert.filesystem.arun')
     async def test_ntfs_real_output_full(self, run):
         run.return_value = read_file('probert/tests/data/ntfsresize_full.out')
         expected = {'SIZE': 83882496, 'ESTIMATED_MIN_SIZE': 83882496}
         self.assertEqual(expected, await get_ntfs_sizing(self.device))
 
-    @patch('probert.filesystem.run')
+    @patch('probert.filesystem.arun')
     async def test_ntfs_simple_output(self, run):
         run.return_value = '''
 Current volume size: 100000000 bytes (100 MB)

--- a/probert/tests/test_filesystem.py
+++ b/probert/tests/test_filesystem.py
@@ -16,9 +16,8 @@
 import random
 import string
 
-import pytest
-from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, Mock, patch
 
 from probert.filesystem import (
     get_dumpe2fs_info,
@@ -40,165 +39,164 @@ def random_string(length=8):
         random.choice(string.ascii_lowercase) for _ in range(length))
 
 
-class TestGetSwapSizing:
-    @pytest.mark.parametrize(
-        "device,expected",
-        (
-            (
-                {"ID_PART_ENTRY_SIZE": 2},
-                {"SIZE": 1024, "ESTIMATED_MIN_SIZE": 0}
-            ),
-            (
-                {
-                    "DEVNAME": "/dev/dm-1",
-                    "DEVTYPE": "disk",
-                    "DM_VG_NAME": "vg1",
-                    "attrs": {
-                        "size": "1073741824",
-                    },
-                },
-                {"SIZE": 1073741824, "ESTIMATED_MIN_SIZE": 0},
-            ),
-        ),
-    )
-    def test_expected_output(self, device, expected):
-        assert expected == get_swap_sizing(device)
+class TestGetSwapSizing(IsolatedAsyncioTestCase):
+    async def test_expected_output_simple(self):
+        device = {"ID_PART_ENTRY_SIZE": 2}
+        expected = {"SIZE": 1024, "ESTIMATED_MIN_SIZE": 0}
+
+        assert expected == await get_swap_sizing(device)
+
+    async def test_expected_output_vg(self):
+        device = {
+            "DEVNAME": "/dev/dm-1",
+            "DEVTYPE": "disk",
+            "DM_VG_NAME": "vg1",
+            "attrs": {
+                "size": "1073741824",
+            },
+        }
+        expected = {"SIZE": 1073741824, "ESTIMATED_MIN_SIZE": 0}
+
+        assert expected == await get_swap_sizing(device)
 
 
-class TestFilesystem(TestCase):
+class TestFilesystem(IsolatedAsyncioTestCase):
     def setUp(self):
         self.device = Mock()
         self.device.device_node = random_string()
 
     @patch('probert.filesystem.run')
-    def test_dumpe2fs_simple_output(self, run):
+    async def test_dumpe2fs_simple_output(self, run):
         run.return_value = '''
 Block count: 1234
 Block size:  4000
 '''
         expected = {'block_count': 1234, 'block_size': 4000}
-        self.assertEqual(expected, get_dumpe2fs_info(self.device))
+        self.assertEqual(expected, await get_dumpe2fs_info(self.device))
 
     @patch('probert.filesystem.run')
-    def test_dumpe2fs_real_output(self, run):
+    async def test_dumpe2fs_real_output(self, run):
         run.return_value = read_file('probert/tests/data/dumpe2fs_ext4.out')
         expected = {'block_count': 10240, 'block_size': 4096}
-        self.assertEqual(expected, get_dumpe2fs_info(self.device))
+        self.assertEqual(expected, await get_dumpe2fs_info(self.device))
 
     @patch('probert.filesystem.run')
-    def test_resize2fs(self, run):
+    async def test_resize2fs(self, run):
         run.return_value = 'Estimated minimum size of the filesystem: 1371\n'
         expected = {'min_blocks': 1371}
-        self.assertEqual(expected, get_resize2fs_info(self.device))
+        self.assertEqual(expected, await get_resize2fs_info(self.device))
 
     @patch('probert.filesystem.get_resize2fs_info')
     @patch('probert.filesystem.get_dumpe2fs_info')
-    def test_ext4(self, dumpe2fs, resize2fs):
+    async def test_ext4(self, dumpe2fs, resize2fs):
         dumpe2fs.return_value = {'block_count': 20000, 'block_size': 1000}
         resize2fs.return_value = {'min_blocks': 4000}
         expected = {'SIZE': 20000 * 1000, 'ESTIMATED_MIN_SIZE': 4000 * 1000}
-        self.assertEqual(expected, get_ext_sizing(self.device))
+        self.assertEqual(expected, await get_ext_sizing(self.device))
 
     @patch('probert.filesystem.get_dumpe2fs_info')
-    def test_ext4_bad_dumpe2fs(self, dumpe2fs):
+    async def test_ext4_bad_dumpe2fs(self, dumpe2fs):
         dumpe2fs.return_value = None
-        self.assertIsNone(get_ext_sizing(self.device))
+        self.assertIsNone(await get_ext_sizing(self.device))
 
     @patch('probert.filesystem.get_resize2fs_info')
     @patch('probert.filesystem.get_dumpe2fs_info')
-    def test_ext4_bad_resize2fs(self, dumpe2fs, resize2fs):
+    async def test_ext4_bad_resize2fs(self, dumpe2fs, resize2fs):
         dumpe2fs.return_value = {'block_count': 20000, 'block_size': 1000}
         resize2fs.return_value = None
         expected = {'SIZE': 20000 * 1000}
-        self.assertEqual(expected, get_ext_sizing(self.device))
+        self.assertEqual(expected, await get_ext_sizing(self.device))
 
     @patch('probert.filesystem.run')
-    def test_ntfs_real_output(self, run):
+    async def test_ntfs_real_output(self, run):
         run.return_value = read_file('probert/tests/data/ntfsresize.out')
         expected = {'SIZE': 41939456, 'ESTIMATED_MIN_SIZE': 2613248}
-        self.assertEqual(expected, get_ntfs_sizing(self.device))
+        self.assertEqual(expected, await get_ntfs_sizing(self.device))
 
     @patch('probert.filesystem.run')
-    def test_ntfs_real_output_full(self, run):
+    async def test_ntfs_real_output_full(self, run):
         run.return_value = read_file('probert/tests/data/ntfsresize_full.out')
         expected = {'SIZE': 83882496, 'ESTIMATED_MIN_SIZE': 83882496}
-        self.assertEqual(expected, get_ntfs_sizing(self.device))
+        self.assertEqual(expected, await get_ntfs_sizing(self.device))
 
     @patch('probert.filesystem.run')
-    def test_ntfs_simple_output(self, run):
+    async def test_ntfs_simple_output(self, run):
         run.return_value = '''
 Current volume size: 100000000 bytes (100 MB)
 You might resize at 25000000 bytes or 25 MB (freeing 75 MB).
 '''
         expected = {'SIZE': 100000000, 'ESTIMATED_MIN_SIZE': 25000000}
-        self.assertEqual(expected, get_ntfs_sizing(self.device))
+        self.assertEqual(expected, await get_ntfs_sizing(self.device))
 
-    def test_swap_sizing(self):
+    async def test_swap_sizing(self):
         device = {'ID_PART_ENTRY_SIZE': 2}
         expected = {'SIZE': 1024, 'ESTIMATED_MIN_SIZE': 0}
-        self.assertEqual(expected, get_swap_sizing(device))
+        self.assertEqual(expected, await get_swap_sizing(device))
 
-    def test_swap_sizing_as_string(self):
+    async def test_swap_sizing_as_string(self):
         device = {'ID_PART_ENTRY_SIZE': "2"}
         expected = {'SIZE': 1024, 'ESTIMATED_MIN_SIZE': 0}
-        self.assertEqual(expected, get_swap_sizing(device))
+        self.assertEqual(expected, await get_swap_sizing(device))
 
-    def test_get_device_filesystem_no_sizing(self):
+    async def test_get_device_filesystem_no_sizing(self):
         data = {'ID_FS_FOO': 'bar'}
         self.device.items = lambda: data.items()
         expected = {'FOO': 'bar'}
-        self.assertEqual(expected, get_device_filesystem(self.device, False))
+        self.assertEqual(expected,
+                         await get_device_filesystem(self.device, False))
 
-    def test_get_device_filesystem_sizing_unsupported(self):
+    async def test_get_device_filesystem_sizing_unsupported(self):
         data = {'ID_FS_TYPE': 'reiserfs'}
         self.device.items = lambda: data.items()
         expected = {'ESTIMATED_MIN_SIZE': -1, 'TYPE': 'reiserfs'}
-        self.assertEqual(expected, get_device_filesystem(self.device, True))
+        self.assertEqual(expected,
+                         await get_device_filesystem(self.device, True))
 
-    def test_get_device_filesystem_missing_info(self):
+    async def test_get_device_filesystem_missing_info(self):
         data = {}
         self.device.items = lambda: data.items()
         expected = {'ESTIMATED_MIN_SIZE': -1}
-        self.assertEqual(expected, get_device_filesystem(self.device, True))
+        self.assertEqual(expected,
+                         await get_device_filesystem(self.device, True))
 
-    def test_get_device_filesystem_sizing_ext4(self):
+    async def test_get_device_filesystem_sizing_ext4(self):
         data = {'ID_FS_TYPE': 'ext4'}
         self.device.items = lambda: data.items()
         size_info = {'ESTIMATED_MIN_SIZE': 1 << 20, 'SIZE': 10 << 20}
-        ext4 = Mock()
+        ext4 = AsyncMock()
         ext4.return_value = size_info
         with patch.dict('probert.filesystem.sizing_tools',
                         {'ext4': ext4}, clear=True):
             expected = size_info.copy()
             expected['TYPE'] = 'ext4'
-            actual = get_device_filesystem(self.device, True)
+            actual = await get_device_filesystem(self.device, True)
             self.assertEqual(expected, actual)
 
-    def test_get_device_filesystem_sizing_ext4_no_min(self):
+    async def test_get_device_filesystem_sizing_ext4_no_min(self):
         data = {'ID_FS_TYPE': 'ext4'}
         self.device.items = lambda: data.items()
         size_info = {'SIZE': 10 << 20}
-        ext4 = Mock()
+        ext4 = AsyncMock()
         ext4.return_value = size_info
         with patch.dict('probert.filesystem.sizing_tools',
                         {'ext4': ext4}, clear=True):
             expected = size_info.copy()
             expected['ESTIMATED_MIN_SIZE'] = -1
             expected['TYPE'] = 'ext4'
-            actual = get_device_filesystem(self.device, True)
+            actual = await get_device_filesystem(self.device, True)
             self.assertEqual(expected, actual)
 
     @patch('probert.filesystem.shutil.which')
-    def test_ntfsresize_not_found(self, which):
+    async def test_ntfsresize_not_found(self, which):
         which.return_value = None
-        self.assertEqual(None, get_ntfs_sizing(self.device))
+        self.assertEqual(None, await get_ntfs_sizing(self.device))
 
     @patch('probert.filesystem.shutil.which')
-    def test_dumpe2fs_not_found(self, which):
+    async def test_dumpe2fs_not_found(self, which):
         which.return_value = None
-        self.assertEqual(None, get_dumpe2fs_info(self.device))
+        self.assertEqual(None, await get_dumpe2fs_info(self.device))
 
     @patch('probert.filesystem.shutil.which')
-    def test_resize2fs_not_found(self, which):
+    async def test_resize2fs_not_found(self, which):
         which.return_value = None
-        self.assertEqual(None, get_resize2fs_info(self.device))
+        self.assertEqual(None, await get_resize2fs_info(self.device))

--- a/probert/tests/test_lvm.py
+++ b/probert/tests/test_lvm.py
@@ -67,7 +67,7 @@ VGS_REPORT_DUPES = 2 * VGS_REPORT
 
 
 @mock.patch('probert.lvm.subprocess.run')
-class TestLvm(unittest.TestCase):
+class TestLvm(unittest.IsolatedAsyncioTestCase):
 
     def test__lvm_report_returns_empty_list_on_err(self, m_run):
         m_run.side_effect = subprocess.CalledProcessError(
@@ -266,8 +266,8 @@ class TestLvm(unittest.TestCase):
     @mock.patch('probert.lvm.lvm_scan')
     @mock.patch('probert.lvm.sane_block_devices')
     @mock.patch('probert.lvm.probe_vgs_report')
-    def test_probe(self, m_vgs, m_blockdevs, m_scan, m_activate, m_size,
-                   m_run):
+    async def test_probe(self, m_vgs, m_blockdevs, m_scan, m_activate, m_size,
+                         m_run):
         size = 1000
         m_size.return_value = size
         m_blockdevs.return_value = CONTEXT
@@ -293,15 +293,15 @@ class TestLvm(unittest.TestCase):
                 }
             }
         }
-        self.assertEqual(expected_result, lvm.probe())
+        self.assertEqual(expected_result, await lvm.probe())
 
     @mock.patch('probert.lvm.read_sys_block_size_bytes')
     @mock.patch('probert.lvm.activate_volgroups')
     @mock.patch('probert.lvm.lvm_scan')
     @mock.patch('probert.lvm.sane_block_devices')
     @mock.patch('probert.lvm.probe_vgs_report')
-    def test_probe_skip_dupes(self, m_vgs, m_blockdevs, m_scan, m_activate,
-                              m_size, m_run):
+    async def test_probe_skip_dupes(self, m_vgs, m_blockdevs, m_scan,
+                                    m_activate, m_size, m_run):
         size = 1000
         m_size.return_value = size
         m_blockdevs.return_value = CONTEXT_DUPES
@@ -333,7 +333,7 @@ class TestLvm(unittest.TestCase):
                 }
             }
         }
-        self.assertEqual(expected_result, lvm.probe())
+        self.assertEqual(expected_result, await lvm.probe())
 
 
 # vi: ts=4 expandtab syntax=python

--- a/probert/tests/test_multipath.py
+++ b/probert/tests/test_multipath.py
@@ -8,7 +8,7 @@ from probert.tests.helpers import random_string
 MP_SEP = multipath.MP_SEP
 
 
-class TestMultipath(unittest.TestCase):
+class TestMultipath(unittest.IsolatedAsyncioTestCase):
 
     @mock.patch('probert.multipath.subprocess.run')
     def test_multipath_show_paths(self, m_run):
@@ -87,12 +87,13 @@ class TestMultipath(unittest.TestCase):
 
     @mock.patch('probert.multipath.multipath_show_paths')
     @mock.patch('probert.multipath.multipath_show_maps')
-    def test_multipath_probe_collects_maps_and_paths(self, m_maps, m_paths):
+    async def test_multipath_probe_collects_maps_and_paths(self, m_maps,
+                                                           m_paths):
         path_string = MP_SEP.join([random_string() for x in range(0, 8)])
         paths = multipath.MPath(*path_string.split(MP_SEP))._asdict()
         maps_string = MP_SEP.join([random_string() for x in range(0, 3)])
         maps = multipath.MMap(*maps_string.split(MP_SEP))._asdict()
         m_maps.return_value = [maps]
         m_paths.return_value = [paths]
-        result = multipath.probe()
+        result = await multipath.probe()
         self.assertDictEqual({'maps': [maps], 'paths': [paths]}, result)

--- a/probert/tests/test_os.py
+++ b/probert/tests/test_os.py
@@ -14,13 +14,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
-from unittest import TestCase
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
 from probert.os import probe, _parse_osprober, _run_os_prober
 
 
-class TestOsProber(TestCase):
+class TestOsProber(IsolatedAsyncioTestCase):
     def tearDown(self):
         _run_os_prober.cache_clear()
 
@@ -122,7 +122,7 @@ class TestOsProber(TestCase):
         self.assertEqual(expected, _parse_osprober(lines))
 
     @patch('probert.os.subprocess.run')
-    def test_osx_run(self, run):
+    async def test_osx_run(self, run):
         run.return_value.stdout = '/dev/sda4:Mac OS X:MacOSX:macosx\n'
         expected = {
             '/dev/sda4': {
@@ -131,26 +131,26 @@ class TestOsProber(TestCase):
                 'type': 'macosx'
             }
         }
-        self.assertEqual(expected, probe())
+        self.assertEqual(expected, await probe())
 
     @patch('probert.os.subprocess.run')
-    def test_empty_run(self, run):
+    async def test_empty_run(self, run):
         run.return_value.stdout = ''
-        self.assertEqual({}, probe())
+        self.assertEqual({}, await probe())
 
     @patch('probert.os.subprocess.run')
-    def test_none_run(self, run):
+    async def test_none_run(self, run):
         run.return_value.stdout = None
-        self.assertEqual({}, probe())
+        self.assertEqual({}, await probe())
 
     @patch('probert.os.subprocess.run')
-    def test_osprober_fail(self, run):
+    async def test_osprober_fail(self, run):
         run.side_effect = subprocess.CalledProcessError(1, 'cmd')
-        self.assertEqual({}, probe())
+        self.assertEqual({}, await probe())
 
     @patch('probert.os.subprocess.run')
-    def test_run_once(self, run):
+    async def test_run_once(self, run):
         run.return_value.stdout = ''
-        self.assertEqual({}, probe())
-        self.assertEqual({}, probe())
+        self.assertEqual({}, await probe())
+        self.assertEqual({}, await probe())
         run.assert_called_once()

--- a/probert/tests/test_prober.py
+++ b/probert/tests/test_prober.py
@@ -6,23 +6,23 @@ from probert.storage import Storage
 from probert.network import NetworkProber
 
 
-class ProbertTestProber(unittest.TestCase):
+class ProbertTestProber(unittest.IsolatedAsyncioTestCase):
 
     def test_prober_init(self):
         p = Prober()
         self.assertNotEqual(p, None)
 
     @patch.object(Prober, 'probe_all')
-    def test_prober_probe_all(self, _probe_all):
+    async def test_prober_probe_all(self, _probe_all):
         p = Prober()
-        p.probe_all()
+        await p.probe_all()
         self.assertTrue(_probe_all.called)
 
     @patch.object(Prober, 'probe_network')
     @patch.object(Prober, 'probe_storage')
-    def test_prober_probe_all_invoke_others(self, _storage, _network):
+    async def test_prober_probe_all_invoke_others(self, _storage, _network):
         p = Prober()
-        p.probe_all()
+        await p.probe_all()
         self.assertTrue(_storage.called)
         self.assertTrue(_network.called)
 
@@ -32,7 +32,7 @@ class ProbertTestProber(unittest.TestCase):
 
     @patch.object(NetworkProber, 'probe')
     @patch.object(Storage, 'probe')
-    def test_prober_probe_all_check_results(self, _storage, _network):
+    async def test_prober_probe_all_check_results(self, _storage, _network):
         p = Prober()
         results = {
             'storage': {'lambic': 99},
@@ -40,7 +40,7 @@ class ProbertTestProber(unittest.TestCase):
         }
         _storage.return_value = results['storage']
         _network.return_value = results['network']
-        p.probe_all()
+        await p.probe_all()
         self.assertTrue(_storage.called)
         self.assertTrue(_network.called)
         self.assertEqual(results, p.get_results())

--- a/probert/utils.py
+++ b/probert/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 from copy import deepcopy
 import glob
 import itertools
@@ -65,6 +66,28 @@ def run(cmdarr, env=None, **kw):
     log.debug('--------------------------------------------------')
     if sp.returncode == 0:
         return sp.stdout
+    return None
+
+
+async def arun(cmdarr, env=None, **kw):
+    """Run the given, with stdout, stderr, and return code always logged.
+    Returns the stdout on command success, or None on command failure."""
+    env = _clean_env(env)
+    sp = await asyncio.create_subprocess_exec(
+            *cmdarr, env=env, stdout=PIPE, stderr=PIPE, **kw)
+    display_cmd = shlex.join(cmdarr)
+    stdout, stderr = await sp.communicate()
+    rc = sp.returncode
+
+    stdout = stdout.decode('utf-8')
+    stderr = stderr.decode('utf-8')
+
+    log.debug(f'Command `{display_cmd}` exited with result: {rc}')
+    _log_stream(stdout, 'stdout')
+    _log_stream(stderr, 'stderr')
+    log.debug('--------------------------------------------------')
+    if sp.returncode == 0:
+        return stdout
     return None
 
 

--- a/probert/zfs.py
+++ b/probert/zfs.py
@@ -183,7 +183,7 @@ def is_zfs_device(device):
     return device.get('ID_FS_TYPE') == 'zfs_member'
 
 
-def probe(context=None, **kw):
+async def probe(context=None, **kw):
     """The ZFS prober examines the ZFS Dubugger (zdb) output which
     produces psuedo-json output.  This is converted to a dictionary
     where for each zpool, we can extract the datasets and determine


### PR DESCRIPTION
The code does not enforce the use of parallelism, but running probes in parallel lead to a sizable speedup in my tests.

During testing, I ran into one issue with parallelism: sometimes the mount probe finds a filesystem mounted under /var/lib/os-prober/mount. This is where os-prober temporarily mounts partitions while it is running.

I reported a bug and opened a PR upstream: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1034485

In the meantime, I added a patch in this series to make sure os-prober runs in a private mount namespace.