### PR TITLE
Fix crash when PARTNAME is invalid utf-8

### DIFF
--- a/probert/filesystem.py
+++ b/probert/filesystem.py
@@ -156,8 +156,14 @@ sizing_tools = {
 
 async def get_device_filesystem(device, sizing):
     # extract ID_FS_* keys into dict, dropping leading ID_FS
-    fs_info = {k.replace('ID_FS_', ''): v
-               for k, v in device.items() if k.startswith('ID_FS_')}
+    # This may look like a stupid way to iterate over a dictionary-like
+    # collection. However, iterating over device.properties.items() will fail
+    # if any of the values is not utf-8 (or whatever the system's encoding is).
+    # We have had multiple reports of PARTNAME being invalid utf-8.
+    # See LP: 2017862
+    keys = [key for key in device.properties if key.startswith('ID_FS_')]
+    fs_info = {k.replace('ID_FS_', ''): device.properties[k] for k in keys}
+
     if sizing:
         fstype = fs_info.get('TYPE', None)
         if fstype in sizing_tools:

--- a/probert/tests/test_filesystem.py
+++ b/probert/tests/test_filesystem.py
@@ -140,28 +140,36 @@ You might resize at 25000000 bytes or 25 MB (freeing 75 MB).
 
     async def test_get_device_filesystem_no_sizing(self):
         data = {'ID_FS_FOO': 'bar'}
-        self.device.items = lambda: data.items()
+        self.device.properties = Mock()
+        self.device.properties.__iter__ = Mock(return_value=iter(data))
+        self.device.properties.__getitem__ = lambda _, x: data[x]
         expected = {'FOO': 'bar'}
         self.assertEqual(expected,
                          await get_device_filesystem(self.device, False))
 
     async def test_get_device_filesystem_sizing_unsupported(self):
         data = {'ID_FS_TYPE': 'reiserfs'}
-        self.device.items = lambda: data.items()
+        self.device.properties = Mock()
+        self.device.properties.__iter__ = Mock(return_value=iter(data))
+        self.device.properties.__getitem__ = lambda _, x: data[x]
         expected = {'ESTIMATED_MIN_SIZE': -1, 'TYPE': 'reiserfs'}
         self.assertEqual(expected,
                          await get_device_filesystem(self.device, True))
 
     async def test_get_device_filesystem_missing_info(self):
         data = {}
-        self.device.items = lambda: data.items()
+        self.device.properties = Mock()
+        self.device.properties.__iter__ = Mock(return_value=iter(data))
+        self.device.properties.__getitem__ = lambda _, x: data[x]
         expected = {'ESTIMATED_MIN_SIZE': -1}
         self.assertEqual(expected,
                          await get_device_filesystem(self.device, True))
 
     async def test_get_device_filesystem_sizing_ext4(self):
         data = {'ID_FS_TYPE': 'ext4'}
-        self.device.items = lambda: data.items()
+        self.device.properties = Mock()
+        self.device.properties.__iter__ = Mock(return_value=iter(data))
+        self.device.properties.__getitem__ = lambda _, x: data[x]
         size_info = {'ESTIMATED_MIN_SIZE': 1 << 20, 'SIZE': 10 << 20}
         ext4 = AsyncMock()
         ext4.return_value = size_info
@@ -174,7 +182,9 @@ You might resize at 25000000 bytes or 25 MB (freeing 75 MB).
 
     async def test_get_device_filesystem_sizing_ext4_no_min(self):
         data = {'ID_FS_TYPE': 'ext4'}
-        self.device.items = lambda: data.items()
+        self.device.properties = Mock()
+        self.device.properties.__iter__ = Mock(return_value=iter(data))
+        self.device.properties.__getitem__ = lambda _, x: data[x]
         size_info = {'SIZE': 10 << 20}
         ext4 = AsyncMock()
         ext4.return_value = size_info


### PR DESCRIPTION
In GPT partitions, the PartitionName field is stored as a utf-16 string. For some reason though, in udev, the value is not converted from utf-16 to utf-8. Instead, the MSB is dropped and the LSB is kept. e.g.,

 * letter A in UTF-16 is 0x0041. It becomes 0x41 (which is letter A)
 * e-ecute (é) in UTF-16 is 0x00E9. It becomes 0xE9
 * euro sign (€) in UTF-16 is 0x20AC. It becomes 0xAC
 * pound sign (£) in UTF-16 is 0x00A3. It becomes 0xA3

In the above examples, only the letter A results in a valid UTF-8 character.

When using pyudev, the values are all expected to be decodable using the system's default encoding.

In probert, it can result in a crash when iterating over all the properties of a block device, that are mapped by pyudev.

To work around the issue, we now stop iterating over all the values. We iterate over the keys and only access the value if we need it.

NOTE: pyudev deprecated the use of `Device.__getitem__`, `Device.__iter__` and similar constructs to access a pyudev.Device property. Instead, one should use `Device.properties.__getitem__`, `Device.properties.__iter__` and so on. In a future version of pyudev, the support for the deprecated constructs will be dropped so we need to start using the recommended alternative.

https://bugs.launchpad.net/subiquity/+bug/2017862