### PR TITLE
record device maj:min in mount data

### DIFF
--- a/probert/mount.py
+++ b/probert/mount.py
@@ -22,7 +22,7 @@ log = logging.getLogger('probert.mount')
 
 def findmnt(data=None):
     if not data:
-        cmd = ['findmnt', '--bytes', '--json']
+        cmd = ['findmnt', '--bytes', '--json', '-o', '+maj:min']
         try:
             result = subprocess.run(cmd, stdout=subprocess.PIPE,
                                     stderr=subprocess.DEVNULL)


### PR DESCRIPTION
I want to make subiquity a bit more subtle in how it handles the install media, which means it needs to understand the pre-existing mounts in the live session a little better. Casper creates some mounts that are pretty hard to decode from the information we save already, but if we record the device major/minor we can pretty reliably map that to a partition.