### PR TITLE
Fix tests fstools

### DIFF
--- a/probert/tests/test_filesystem.py
+++ b/probert/tests/test_filesystem.py
@@ -196,17 +196,17 @@ You might resize at 25000000 bytes or 25 MB (freeing 75 MB).
             actual = await get_device_filesystem(self.device, True)
             self.assertEqual(expected, actual)
 
-    @patch('probert.filesystem.shutil.which')
-    async def test_ntfsresize_not_found(self, which):
-        which.return_value = None
+
+@patch('probert.filesystem.shutil.which', new=Mock(return_value=None))
+class TestFilesystemToolNotFound(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.device = Mock()
+
+    async def test_ntfsresize_not_found(self):
         self.assertEqual(None, await get_ntfs_sizing(self.device))
 
-    @patch('probert.filesystem.shutil.which')
-    async def test_dumpe2fs_not_found(self, which):
-        which.return_value = None
+    async def test_dumpe2fs_not_found(self):
         self.assertEqual(None, await get_dumpe2fs_info(self.device))
 
-    @patch('probert.filesystem.shutil.which')
-    async def test_resize2fs_not_found(self, which):
-        which.return_value = None
+    async def test_resize2fs_not_found(self):
         self.assertEqual(None, await get_resize2fs_info(self.device))

--- a/probert/tests/test_filesystem.py
+++ b/probert/tests/test_filesystem.py
@@ -60,6 +60,7 @@ class TestGetSwapSizing(IsolatedAsyncioTestCase):
         assert expected == await get_swap_sizing(device)
 
 
+@patch('probert.filesystem.shutil.which', new=Mock(return_value='/bin/false'))
 class TestFilesystem(IsolatedAsyncioTestCase):
     def setUp(self):
         self.device = Mock()

--- a/probert/tests/test_os.py
+++ b/probert/tests/test_os.py
@@ -154,3 +154,9 @@ class TestOsProber(IsolatedAsyncioTestCase):
         self.assertEqual({}, await probe())
         self.assertEqual({}, await probe())
         run.assert_called_once()
+
+
+@patch('probert.filesystem.shutil.which', new=Mock(return_value=None))
+class TestOsProberNotFound(IsolatedAsyncioTestCase):
+    async def test_os_prober_not_found(self):
+        self.assertEqual(None, _run_os_prober())

--- a/probert/tests/test_os.py
+++ b/probert/tests/test_os.py
@@ -15,11 +15,12 @@
 
 import subprocess
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from probert.os import probe, _parse_osprober, _run_os_prober
 
 
+@patch('probert.filesystem.shutil.which', new=Mock(return_value='/bin/false'))
 class TestOsProber(IsolatedAsyncioTestCase):
     def tearDown(self):
         _run_os_prober.cache_clear()


### PR DESCRIPTION
The probert unit tests may fail, depending on if filesystem tools are installed on the host system.  We don't actually run them, that's already mocked out.  Mock out the check for them existing.