### PR TITLE
Also return info about NVMe devices

### DIFF
--- a/probert/nvme.py
+++ b/probert/nvme.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+import pyudev
+
+from probert.utils import udev_get_attributes
+
+log = logging.getLogger('probert.nvme')
+
+
+async def probe(context=None, **kw):
+    if not context:
+        context = pyudev.Context()
+
+    nvme_controllers = {}
+    for controller in context.list_devices(subsystem='nvme'):
+        props = dict(controller.properties)
+        props['attrs'] = udev_get_attributes(controller)
+        nvme_controllers[controller.sys_name] = props
+
+    return nvme_controllers

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -26,7 +26,7 @@ from probert.utils import (
     udev_get_attributes,
     )
 from probert import (bcache, dasd, dmcrypt, filesystem, lvm, mount, multipath,
-                     os, raid, zfs)
+                     nvme, os, raid, zfs)
 
 log = logging.getLogger('probert.storage')
 
@@ -198,6 +198,7 @@ class Storage():
         'lvm': Probe(lvm.probe),
         'mount': Probe(mount.probe),
         'multipath': Probe(multipath.probe),
+        'nvme': Probe(nvme.probe),
         'os': Probe(os.probe, in_default_set=False),
         'filesystem_sizing': Probe(null_probe, in_default_set=False),
         'raid': Probe(raid.probe),


### PR DESCRIPTION
Block probing now includes a new key called "nvme" which contains a Udev dump of the `SUBSYSTEM="nvme"` devices. Each entry corresponds to a NVMe controller and has all the properties we need to find out if drives using this NVMe controller are "local", "over TCP" or soemthing else.