### PR TITLE
do not pass strict versions to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,6 @@ def pkgconfig(package):
         'extra_link_args': subprocess.check_output(['pkg-config', '--libs', package]).decode('utf8').split(),
     }
 
-
-def read_requirement():
-    return [req.strip() for req in open('requirements.txt')]
-
-
 setup(name='probert',
       version=probert.__version__,
       description="Hardware probing tool",
@@ -66,6 +61,6 @@ setup(name='probert',
             **pkgconfig("libnl-genl-3.0")),
           ],
       packages=find_packages(),
-      install_requires=read_requirement(),
+      install_requires=['jsonschema', 'pyudev'],
       include_package_data=True,
 )


### PR DESCRIPTION
It does not make sense for install_requires to specify a version of jsonschema that is over 7 years old.