### PR TITLE
Query size of device using devpath rather than devname - also enables more logging on error

### DIFF
--- a/probert/storage.py
+++ b/probert/storage.py
@@ -21,7 +21,7 @@ import pyudev
 import subprocess
 
 from probert.utils import (
-    read_sys_block_size_bytes,
+    read_sys_devpath_size_bytes,
     sane_block_devices,
     udev_get_attributes,
     )
@@ -135,11 +135,12 @@ async def blockdev_probe(context=None, **kw):
     blockdev = {}
     for device in interesting_storage_devs(context):
         devname = device.properties['DEVNAME']
+        devpath = device.properties['DEVPATH']
         attrs = udev_get_attributes(device)
         # update the size attr as it may only be the number
         # of blocks rather than size in bytes.
-        attrs['size'] = \
-            str(read_sys_block_size_bytes(devname))
+        attrs['size'] = str(read_sys_devpath_size_bytes(
+            devpath, log_inexistent=True))
         # When dereferencing device[prop], pyudev calls bytes.decode(), which
         # can fail if the value is invalid utf-8. We don't want a single
         # invalid value to completely prevent probing. So we iterate

--- a/probert/tests/test_utils.py
+++ b/probert/tests/test_utils.py
@@ -63,6 +63,20 @@ class ProbertTestUtils(unittest.TestCase):
             self.assertEqual(expected_bytes, result)
             self.assertEqual([call(expected_fname)], m_open.call_args_list)
 
+    def test_utils_read_sys_devpath_size_bytes_strips_value(self):
+        devpath = """\
+/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0/nvme0n1/nvme0n1p3"""
+        expected_path = pathlib.Path(f'/sys{devpath}/size')
+        expected_bytes = 10737418240
+        content = ' 20971520 \n '
+
+        with unittest.mock.patch("probert.utils.Path.read_text",
+                                 autospec=True,
+                                 return_value=content) as m_read_text:
+            result = utils.read_sys_devpath_size_bytes(devpath)
+            self.assertEqual(expected_bytes, result)
+            self.assertEqual([call(expected_path)], m_read_text.call_args_list)
+
 
 @contextlib.contextmanager
 def create_script(content):

--- a/probert/tests/test_utils.py
+++ b/probert/tests/test_utils.py
@@ -1,13 +1,14 @@
 import contextlib
 import logging
 import os
+import pathlib
 import tempfile
 import textwrap
 import unittest
 from unittest.mock import call
 
 from probert import utils
-from probert.tests.helpers import random_string, simple_mocked_open
+from probert.tests.helpers import random_string
 
 
 class ProbertTestUtils(unittest.TestCase):
@@ -45,23 +46,31 @@ class ProbertTestUtils(unittest.TestCase):
 
     def test_utils_read_sys_block_size_bytes(self):
         devname = random_string()
-        expected_fname = '/sys/class/block/%s/size' % devname
+        expected_path = pathlib.Path(f'/sys/class/block/{devname}/size')
         expected_bytes = 10737418240
         content = '20971520'
-        with simple_mocked_open(content=content) as m_open:
+
+        with unittest.mock.patch("probert.utils.Path.read_text",
+                                 autospec=True,
+                                 return_value=content) as m_read_text:
             result = utils.read_sys_block_size_bytes(devname)
             self.assertEqual(expected_bytes, result)
-            self.assertEqual([call(expected_fname)], m_open.call_args_list)
+            m_read_text.assert_called_once()
+            self.assertEqual([call(expected_path)], m_read_text.call_args_list)
 
     def test_utils_read_sys_block_size_bytes_strips_value(self):
         devname = random_string()
-        expected_fname = '/sys/class/block/%s/size' % devname
+        expected_path = pathlib.Path(f'/sys/class/block/{devname}/size')
         expected_bytes = 10737418240
         content = ' 20971520 \n '
-        with simple_mocked_open(content=content) as m_open:
+
+        with unittest.mock.patch("probert.utils.Path.read_text",
+                                 autospec=True,
+                                 return_value=content) as m_read_text:
             result = utils.read_sys_block_size_bytes(devname)
             self.assertEqual(expected_bytes, result)
-            self.assertEqual([call(expected_fname)], m_open.call_args_list)
+            m_read_text.assert_called_once()
+            self.assertEqual([call(expected_path)], m_read_text.call_args_list)
 
     def test_utils_read_sys_devpath_size_bytes_strips_value(self):
         devpath = """\

--- a/probert/utils.py
+++ b/probert/utils.py
@@ -7,6 +7,7 @@ import os
 import re
 import shlex
 import subprocess
+from pathlib import Path
 from subprocess import PIPE
 
 import pyudev
@@ -301,6 +302,14 @@ def read_sys_block_size_bytes(device):
         size = int(d.read().strip()) * SECTOR_SIZE_BYTES
 
     return size
+
+
+def read_sys_devpath_size_bytes(devpath: Path | str) -> int:
+    """ Based on the value of a DEVPATH udev property, return the associated
+    size (converted to bytes) by reading from the sysfs. """
+    path = Path("/sys") / Path(devpath).relative_to("/") / "size"
+
+    return int(path.read_text().strip()) * SECTOR_SIZE_BYTES
 
 
 def read_sys_block_slaves(device):

--- a/probert/utils.py
+++ b/probert/utils.py
@@ -294,14 +294,12 @@ def parse_etc_network_interfaces(ifaces, contents, path):
             ifaces[iface]['auto'] = False
 
 
-def read_sys_block_size_bytes(device):
-    """ /sys/class/block/<device>/size and return integer value in bytes"""
-    device_dir = os.path.join('/sys/class/block', os.path.basename(device))
-    blockdev_size = os.path.join(device_dir, 'size')
-    with open(blockdev_size) as d:
-        size = int(d.read().strip()) * SECTOR_SIZE_BYTES
-
-    return size
+def read_sys_block_size_bytes(device: str) -> int:
+    """ /sys/class/block/<device>/size and return integer value in bytes.
+    NOTE: if you are not sure whether the /sys/class/block/<device> directory
+    exists, consider using read_sys_devpath_size_bytes instead. """
+    path = Path("/sys/class/block") / os.path.basename(device) / "size"
+    return int(path.read_text().strip()) * SECTOR_SIZE_BYTES
 
 
 def read_sys_devpath_size_bytes(devpath: Path | str) -> int:

--- a/probert/utils.py
+++ b/probert/utils.py
@@ -302,12 +302,20 @@ def read_sys_block_size_bytes(device: str) -> int:
     return int(path.read_text().strip()) * SECTOR_SIZE_BYTES
 
 
-def read_sys_devpath_size_bytes(devpath: Path | str) -> int:
+def read_sys_devpath_size_bytes(devpath: Path | str,
+                                log_inexistent=False) -> int:
     """ Based on the value of a DEVPATH udev property, return the associated
     size (converted to bytes) by reading from the sysfs. """
     path = Path("/sys") / Path(devpath).relative_to("/") / "size"
 
-    return int(path.read_text().strip()) * SECTOR_SIZE_BYTES
+    try:
+        return int(path.read_text().strip()) * SECTOR_SIZE_BYTES
+    except FileNotFoundError:
+        if log_inexistent:
+            # path.parent.iterdir can raise another FileNotFoundError exception
+            # This is fine, we will know it means the directory does not exist.
+            log.warning("%s contains %s", path.parent, list(path.parent.iterdir()))
+        raise
 
 
 def read_sys_block_slaves(device):


### PR DESCRIPTION
In LP:#2063433 and private reports associated to it, we observe that sometimes, accessing `/sys/class/block/<devname>/size` fails with `FileNotFoundError`.

It isn't easy to determine whether the `size` file does not exist or the parent directory itself.

We now rely on a new way to retrieve the size, using the devpath instead of the devname. Hopefully, the devpath should always exist in sysfs if udev says so?

As for errors, we will now try to list the files from the parent directory when a `FileNotFoundException` is found as the result of the new function.