### PR TITLE
Add way to probe firmware information

### DIFF
--- a/bin/probert
+++ b/bin/probert
@@ -33,6 +33,8 @@ def parse_options(argv):
                         help='Probe storage hardware.')
     parser.add_argument('--network', action='store_true',
                         help='Probe network hardware.')
+    parser.add_argument("--firmware", action='store_true',
+                        help='Probe firmware')
     parser.add_argument('--parallel', action='store_true',
                         help='Run storage probes in parallel')
     return parser.parse_args(argv)
@@ -46,13 +48,15 @@ async def main():
     logger.info("Arguments passed: {}".format(sys.argv))
 
     p = prober.Prober()
-    probe_opts = [opts.network, opts.storage]
+    probe_opts = [opts.network, opts.storage, opts.firmware]
     if opts.all or not any(probe_opts):
         await p.probe_all(parallelize=opts.parallel)
     if opts.network:
         await p.probe_network()
     if opts.storage:
         await p.probe_storage(parallelize=opts.parallel)
+    if opts.firmware:
+        await p.probe_firmware(parallelize=opts.parallel)
 
     results = p.get_results()
     print(json.dumps(results, indent=4, sort_keys=True))

--- a/bin/probert
+++ b/bin/probert
@@ -52,7 +52,7 @@ async def main():
     if opts.all or not any(probe_opts):
         await p.probe_all(parallelize=opts.parallel)
     if opts.network:
-        await p.probe_network()
+        p.probe_network()
     if opts.storage:
         await p.probe_storage(parallelize=opts.parallel)
     if opts.firmware:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 probert (0.0.21) UNRELEASED; urgency=medium
 
-    *
+  * Add probert-firmware to probe information about the firmware.
 
  -- Olivier Gayot <olivier.gayot@canonical.com>  Tue, 02 Jul 2024 15:55:59 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+probert (0.0.21) UNRELEASED; urgency=medium
+
+    *
+
+ -- Olivier Gayot <olivier.gayot@canonical.com>  Tue, 02 Jul 2024 15:55:59 +0200
+
 probert (0.0.20) groovy; urgency=medium
 
   [ Ryan Harper ]

--- a/debian/control
+++ b/debian/control
@@ -74,3 +74,16 @@ Description: Hardware probing tool - network probing
  and emitting a JSON report.
  .
  This package contains network probing capability.
+
+Package: probert-firmware
+Architecture: all
+Depends: probert-common (= ${source:Version}),
+         dmidecode,
+         ${misc:Depends},
+         ${python3:Depends},
+         ${shlibs:Depends}
+Description: Hardware probing tool - firmware probing
+ This package provides a tool for probing host hardware information
+ and emitting a JSON report.
+ .
+ This package contains firmware probing capability.

--- a/debian/probert-firmware.install
+++ b/debian/probert-firmware.install
@@ -1,0 +1,1 @@
+usr/lib/python3.*/dist-packages/probert/firmware.py

--- a/probert/firmware.py
+++ b/probert/firmware.py
@@ -1,0 +1,70 @@
+# Copyright 2024 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Collect information about the firmware. Unlike network and storage, which
+support hotplugging, firmware information should not need to be queried
+multiple times."""
+
+import logging
+import shutil
+from typing import Any
+
+from probert.utils import arun
+
+
+log = logging.getLogger('probert.firmware')
+
+
+schema = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["bios-vendor", "bios-version", "bios-release-date"],
+    "properties": {
+        "bios-vendor": {
+            "type": ["string", "null"],
+        },
+        "bios-version": {
+            "type": ["string", "null"],
+        },
+        "bios-release-data": {
+            "type": ["string", "null"],
+        },
+    },
+}
+
+
+class FirmwareProber:
+    async def _probe_bios_string(self, string: str) -> str | None:
+        dmidecode = shutil.which("dmidecode")
+        if dmidecode is None:
+            log.debug("could not determine bios %s: dmidecode not found",
+                      string)
+            return None
+
+        out = await arun([dmidecode, "--string", string])
+        if out is None:
+            log.warning("could not determine bios %s: dmidecode failure",
+                        string)
+        else:
+            out = out.strip()
+        return out
+
+    async def probe(self) -> dict[str, Any]:
+        return {
+            "bios-vendor": await self._probe_bios_string("bios-vendor"),
+            "bios-version": await self._probe_bios_string("bios-version"),
+            "bios-release-date":
+                await self._probe_bios_string("bios-release-date"),
+        }

--- a/probert/prober.py
+++ b/probert/prober.py
@@ -19,6 +19,7 @@ class Prober():
 
     async def probe_all(self, *, parallelize=False):
         await self.probe_storage()
+        await self.probe_firmware()
         self.probe_network()
 
     async def probe_storage(self, *, parallelize=False):
@@ -26,6 +27,11 @@ class Prober():
         self._storage = Storage()
         self._results['storage'] = await self._storage.probe(
                 parallelize=parallelize)
+
+    async def probe_firmware(self, *, parallelize=False):
+        from probert.firmware import FirmwareProber
+        self._firmware = FirmwareProber()
+        self._results['firmware'] = await self._firmware.probe()
 
     def probe_network(self):
         from probert.network import NetworkProber

--- a/probert/tests/test_prober.py
+++ b/probert/tests/test_prober.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from probert.prober import Prober
+from probert.firmware import FirmwareProber
 from probert.storage import Storage
 from probert.network import NetworkProber
 
@@ -30,17 +31,22 @@ class ProbertTestProber(unittest.IsolatedAsyncioTestCase):
         p = Prober()
         self.assertEqual({}, p.get_results())
 
+    @patch.object(FirmwareProber, 'probe')
     @patch.object(NetworkProber, 'probe')
     @patch.object(Storage, 'probe')
-    async def test_prober_probe_all_check_results(self, _storage, _network):
+    async def test_prober_probe_all_check_results(
+            self, _storage, _network, _firmware):
         p = Prober()
         results = {
             'storage': {'lambic': 99},
             'network': {'saison': 99},
+            'firmware': {'tripel': 99},
         }
         _storage.return_value = results['storage']
         _network.return_value = results['network']
+        _firmware.return_value = results['firmware']
         await p.probe_all()
         self.assertTrue(_storage.called)
         self.assertTrue(_network.called)
+        self.assertTrue(_firmware.called)
         self.assertEqual(results, p.get_results())


### PR DESCRIPTION
For NVMe/TCP, we will want Subiquity to determine if booting with the boot FS on remote-storage is supported by the firmware. So far, it looks like we might need to rely on the "bios-vendor" value so we now expose this information from probert.

Since firmware related information should not change between two different probert invocations now make it part of a "firmware" prober, that Subiquity should realistically call only once.

