### PR TITLE
nvme: run `nvme connect-all --nbft` before running the actual probes

### DIFF
--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -196,6 +196,8 @@ async def probe(context=None, **kw):
         older LVM2 stacks, the LVM probe may be incomplete.
     """
     # scan and activate lvm vgs/lvs
+    # TODO it feels like the activation code should be moved to
+    # Storage.activate_devices.
     lvm_scan()
     activate_volgroups()
 

--- a/probert/nvme.py
+++ b/probert/nvme.py
@@ -13,10 +13,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import subprocess
 
 import pyudev
 
-from probert.utils import udev_get_attributes
+from probert.utils import arun, udev_get_attributes
 
 log = logging.getLogger('probert.nvme')
 
@@ -32,3 +33,11 @@ async def probe(context=None, **kw):
         nvme_controllers[controller.sys_name] = props
 
     return nvme_controllers
+
+
+async def connect_nbft() -> None:
+    cmd = ['nvme', 'connect-all', '--nbft']
+    try:
+        await arun(cmd)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        log.error('Failed to run cmd: %s', cmd)


### PR DESCRIPTION
When running in an environment where a NBFT is available, we want probert to collect information about the remote NVMe drives too.

This can be done by calling the `nvme connect-all --nbft` command. That said, running the command in the NVMe probe code itself will be too late for other probes (e.g., blockdev, filesystem, ...) to pick-up information about the remote NVMe drives.

Instead, we run the command before dispatching the probes ; in a function called "activate_devices". In the long run, I would like to move some code that is currently in the probes (e.g., `vgchange --activate=y`) to the activate_devices function ; to avoid side effects in the probe code.