### PR TITLE
Make it optional to use the WLAN listener

### DIFF
--- a/probert/network.py
+++ b/probert/network.py
@@ -785,7 +785,7 @@ class UdevObserver(NetworkObserver):
             link.wlan['ssid'] = None
 
 
-class StoredDataObserver:
+class StoredDataObserver(NetworkObserver):
     """A cheaty observer that just pretends the network is in some
        pre-arranged state."""
 

--- a/probert/network.py
+++ b/probert/network.py
@@ -28,9 +28,9 @@ from probert.utils import udev_get_attributes
 log = logging.getLogger('probert.network')
 
 try:
-    from probert import _nl80211, _rtnetlink
+    from probert import _rtnetlink
 except ImportError as e:
-    log.warning('Failed import network library modules: %s', e)
+    log.warning('Failed import _rtnetlink library modules: %s', e)
 
 # Standard interface flags (net/if.h)
 IFF_UP = 0x1                   # Interface is up.
@@ -634,6 +634,9 @@ class UdevObserver(NetworkObserver):
     """Use udev/netlink to observe network changes."""
 
     def __init__(self, receiver=None, *, with_wlan_listener: bool = True):
+        """ Listen to and handle network events using our _rtnetlink Python
+            extension. Also optionally use our _nl80211 Python extension for
+            scanning when with_wlan_listener is True. """
         self._links = {}
         self.context = pyudev.Context()
         if receiver is None:
@@ -643,6 +646,7 @@ class UdevObserver(NetworkObserver):
         self._calls = None
 
         if with_wlan_listener:
+            from probert import _nl80211
             self.wlan_listener = _nl80211.listener(self)
         else:
             self.wlan_listener = None

--- a/probert/tests/test_network.py
+++ b/probert/tests/test_network.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Canonical, Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import Mock, patch
+
+from probert.network import UdevObserver
+
+
+class TestUdevObserver(unittest.TestCase):
+    def test_init_no_nl80211(self):
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "probert" and "_nl80211" in fromlist:
+                raise ImportError
+            return orig_import(name)
+
+        orig_import = __import__
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            with self.assertRaises(ImportError):
+                UdevObserver(with_wlan_listener=True)
+            observer = UdevObserver(with_wlan_listener=False)
+
+        self.assertIsNone(observer.wlan_listener)
+
+    def test_init_with_nl80211(self):
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "probert" and "_nl80211" in fromlist:
+                return Mock()
+            return orig_import(name)
+
+        orig_import = __import__
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            observer = UdevObserver(with_wlan_listener=True)
+            self.assertIsNotNone(observer.wlan_listener)
+
+            observer = UdevObserver(with_wlan_listener=False)
+            self.assertIsNone(observer.wlan_listener)


### PR DESCRIPTION
Our `_nl80211` Python module sometimes crashes. Although, we haven't managed to reproduce the crash yet, we have seen occurrences of the crash on the desktop installer, e.g., https://bugs.launchpad.net/ubuntu/+source/probert/+bug/2071620

That said, it looks like the desktop installer does not really need the `_nl80211` module. It currently interacts with NetworkManager directly.

Let's make it optional to use the `_nl80211` module. To disable its use, one can now pass `with_wlan_observer=True` when instantiating the UdevObserver class.