### PR TITLE
network: handle missing SSID information element

### DIFF
--- a/probert/_nl80211module.c
+++ b/probert/_nl80211module.c
@@ -420,6 +420,18 @@ static void extract_ssid(struct nlattr *data, struct scan_handler_params *p)
 	char *ie = nla_data(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
 	size_t ie_len = nla_len(bss[NL80211_BSS_INFORMATION_ELEMENTS]);
 	char *ssid = nl80211_get_ie(ie, ie_len, 0);
+
+	if (ssid == NULL) {
+		/*
+		 * LP: #2104087 For reasons yet to be determined, the SSID information
+		 * element (aka. IE) can sometimes be completely missing.
+		 * We have speculated that it could be related to hidden SSIDs but
+		 * testing showed that having an SSID information element with size 0
+		 * is a thing.
+		 */
+		return;
+	}
+
 	ssize_t ssid_len = (ssize_t)ssid[1];
 	PyObject* v = Py_BuildValue("(y#s)", ssid + 2, ssid_len, cstatus);
 	if (v == NULL) {


### PR DESCRIPTION
In some situations (details are unknown), the SSID information element can be missing for a given network. This lead to a NULL pointer dereference when trying to extract the SSID, causing a crash of the Python process.

Ensure we ignore the SSID rather than crashing.

[LP: #2104087](https://launchpad.net/bugs/2104087)