### PR TITLE
nl80211: handle information elements with length > 0x7F

### DIFF
--- a/probert/_nl80211module.c
+++ b/probert/_nl80211module.c
@@ -366,7 +366,13 @@ static int nl80211_trigger_scan(struct Listener *listener, int ifidx) {
 }
 
 static char *nl80211_get_ie(char *ies, size_t ies_len, char ie) {
-	char *end, *pos;
+	/*
+	 * It is important to work with unsigned here because the length field of
+	 * an IE is one byte. If the length is > 0x7F and we're working with signed
+	 * chars, we will interpret it as a negative length, causing various issues
+	 * like infinite loops.
+	 */
+	unsigned char *end, *pos;
 
 	if (ies == NULL)
 		return NULL;


### PR DESCRIPTION
Reading the ieee80211 implementation in the kernel [1], it looks like information elements can have a length of up-to 0xFF. Because we were working with signed chars (well, depends on the compilation flags) in `nl80211_get_ie`, we could interpret the length as a negative value.

The length is later used to "jump" to the next IE. So if we are interpreting it as a negative value, we're definitely going to read memory that we should not be reading.

I suppose this is what happens in https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/2060894

[1] https://github.com/torvalds/linux/blob/1a9239bb4253f9076b5b4b2a1a4e8d7defd77a95/include/linux/ieee80211.h#L4841-L4845