### PR TITLE
network: fix use of undefined variables in main block

### DIFF
--- a/probert/network.py
+++ b/probert/network.py
@@ -861,7 +861,7 @@ if __name__ == '__main__':
     c = UdevObserver()
     fds = c.start()
 
-    pprint.pprint(c.links)
+    pprint.pprint(c._links)
 
     poll_ob = select.epoll()
     for fd in fds:
@@ -870,4 +870,4 @@ if __name__ == '__main__':
         events = poll_ob.poll()
         for (fd, e) in events:
             c.data_ready(fd)
-        pprint.pprint(c.links)
+        pprint.pprint(c._links)


### PR DESCRIPTION
This main block in network.py is not exposed by the "probert" CL tool. However it can be used as an example to test some of the nl80211 code.

It has been broken for years, let's at least fix the use of undefined variables.