### PR TITLE
Fix warnings from recent patches

### DIFF
--- a/probert/_nl80211module.c
+++ b/probert/_nl80211module.c
@@ -377,14 +377,14 @@ static char *nl80211_get_ie(char *ies, size_t ies_len, char ie) {
 	if (ies == NULL)
 		return NULL;
 
-	pos = ies;
-	end = ies + ies_len;
+	pos = (unsigned char *)ies;
+	end = (unsigned char *)ies + ies_len;
 
 	while (pos + 1 < end) {
 		if (pos + 2 + pos[1] > end)
 			break;
 		if (pos[0] == ie)
-			return pos;
+			return (char *)pos;
 		pos += 2 + pos[1];
 	}
 

--- a/probert/_rtnetlinkmodule.c
+++ b/probert/_rtnetlinkmodule.c
@@ -411,14 +411,15 @@ get_correct_link_object(struct nl_cache *link_cache, int ifindex)
 
 	rtnl_link_set_ifindex(filter, ifindex);
 
+	typedef void (*cb_type_t)(struct nl_object *, void *);
 	void cb(struct rtnl_link *candidate, struct rtnl_link **linkp) {
 		if (rtnl_link_get_family(candidate) != AF_INET6) {
-			nl_object_get(candidate);
+			nl_object_get(OBJ_CAST(candidate));
 			*linkp = candidate;
 		}
 	}
 
-	nl_cache_foreach_filter(link_cache, filter, cb, &rv);
+	nl_cache_foreach_filter(link_cache, OBJ_CAST(filter), (cb_type_t)cb, &rv);
 
 	rtnl_link_put(filter);
 


### PR DESCRIPTION
The subiquity CI is a bit pedantic and will fail if probert builds with warnings.

Let's address the warnings that it complains about.

```
probert/_rtnetlinkmodule.c: In function ‘cb’:
probert/_rtnetlinkmodule.c:416:39: error: passing argument 1 of ‘nl_object_get’ from incompatible pointer type [-Wincompatible-pointer-types]
  416 |                         nl_object_get(candidate);
      |                                       ^~~~~~~~~
      |                                       |
      |                                       struct rtnl_link *
In file included from /usr/include/libnl3/netlink/netlink.h:29,
                 from /usr/include/libnl3/netlink/cache.h:9,
                 from probert/_rtnetlinkmodule.c:7:
/usr/include/libnl3/netlink/object.h:30:47: note: expected ‘struct nl_object *’ but argument is of type ‘struct rtnl_link *’
   30 | extern void                     nl_object_get(struct nl_object *);
      |                                               ^~~~~~~~~~~~~~~~~~
probert/_rtnetlinkmodule.c: In function ‘get_correct_link_object’:
probert/_rtnetlinkmodule.c:421:45: error: passing argument 2 of ‘nl_cache_foreach_filter’ from incompatible pointer type [-Wincompatible-pointer-types]
  421 |         nl_cache_foreach_filter(link_cache, filter, cb, &rv);
      |                                             ^~~~~~
      |                                             |
      |                                             struct rtnl_link *
/usr/include/libnl3/netlink/cache.h:116:57: note: expected ‘struct nl_object *’ but argument is of type ‘struct rtnl_link *’
  116 |                                                         struct nl_object *,
      |                                                         ^~~~~~~~~~~~~~~~~~
probert/_rtnetlinkmodule.c:421:53: error: passing argument 3 of ‘nl_cache_foreach_filter’ from incompatible pointer type [-Wincompatible-pointer-types]
  421 |         nl_cache_foreach_filter(link_cache, filter, cb, &rv);
      |                                                     ^~
      |                                                     |
      |                                                     void (*)(struct rtnl_link *, struct rtnl_link **)
/usr/include/libnl3/netlink/cache.h:117:64: note: expected ‘void (*)(struct nl_object *, void *)’ but argument is of type ‘void (*)(struct rtnl_link *, struct rtnl_link **)’
  117 |                                                         void (*cb)(struct
      |                                                         ~~~~~~~^~~~~~~~~~
  118 |                                                                    nl_object *,
      |                                                                    ~~~~~~~~~~~~
  119 |                                                                    void *),
      |                                                                    ~~~~~~~
```