### PR TITLE
Also report VG-s / PV-s when a VG has no LV

### DIFF
--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -172,10 +172,10 @@ def extract_lvm_volgroup(vg_name, report_data):
     if size is None:
         size = '0B'
 
-    return (vg_name, {'name': vg_name,
-                      'devices': sorted(list(devices)),
-                      'size': size,
-                      'partial': missing_pvs > 0})
+    return {'name': vg_name,
+            'devices': sorted(list(devices)),
+            'size': size,
+            'partial': missing_pvs > 0}
 
 
 async def probe(context=None, **kw):
@@ -225,8 +225,8 @@ async def probe(context=None, **kw):
                 log.error('Found duplicate logical volume: %s', lv_id)
                 continue
 
-            vg_name = device['DM_VG_NAME']
-            (vg_id, new_vg) = extract_lvm_volgroup(vg_name, vg_report)
+            vg_id = vg_name = device['DM_VG_NAME']
+            new_vg = extract_lvm_volgroup(vg_name, vg_report)
             if vg_id not in vgroups:
                 vgroups[vg_id] = new_vg
             else:

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -216,6 +216,10 @@ async def probe(context=None, **kw):
     pvols = {}
     vg_report = probe_vgs_report()
 
+    for vg_name in {vg['vg_name'] for vg in vg_report}:
+        vgroups[vg_name] = extract_lvm_volgroup(vg_name, vg_report)
+        pvols[vg_name] = vgroups[vg_name]['devices']
+
     for device in sane_block_devices(context):
         if 'DM_UUID' in device and device['DM_UUID'].startswith('LVM'):
             (lv_id, new_lv) = extract_lvm_partition(device)
@@ -224,16 +228,6 @@ async def probe(context=None, **kw):
             else:
                 log.error('Found duplicate logical volume: %s', lv_id)
                 continue
-
-            vg_id = vg_name = device['DM_VG_NAME']
-            new_vg = extract_lvm_volgroup(vg_name, vg_report)
-            if vg_id not in vgroups:
-                vgroups[vg_id] = new_vg
-            else:
-                continue
-
-            if vg_id not in pvols:
-                pvols[vg_id] = new_vg['devices']
 
     lvm = {}
     if lvols:

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -230,7 +230,6 @@ async def probe(context=None, **kw):
             if vg_id not in vgroups:
                 vgroups[vg_id] = new_vg
             else:
-                log.error('Found duplicate volume group: %s', vg_id)
                 continue
 
             if vg_id not in pvols:

--- a/probert/tests/test_lvm.py
+++ b/probert/tests/test_lvm.py
@@ -225,10 +225,10 @@ class TestLvm(unittest.IsolatedAsyncioTestCase):
                      "vg_size": "doesnt_end_with_B_"}
                 ]"""))
         self.assertEqual(
-            ("vg0", {'name': "vg0",
-                     'devices': sorted(['/dev/md0', '/dev/md1', '/dev/md2']),
-                     'size': '21449670656B',
-                     'partial': False}),
+            {'name': "vg0",
+             'devices': sorted(['/dev/md0', '/dev/md1', '/dev/md2']),
+             'size': '21449670656B',
+             'partial': False},
             lvm.extract_lvm_volgroup('vg0', input_data))
 
     def test_extract_lvm_volgroup__partial(self, m_run):
@@ -247,10 +247,10 @@ class TestLvm(unittest.IsolatedAsyncioTestCase):
                      "vg_size": "21449670656B"}
                 ]"""))
         self.assertEqual(
-            ("vg0", {'name': "vg0",
-                     'devices': sorted(['/dev/md0']),
-                     'size': '21449670656B',
-                     'partial': True}),
+            {'name': "vg0",
+             'devices': sorted(['/dev/md0']),
+             'size': '21449670656B',
+             'partial': True},
             lvm.extract_lvm_volgroup('vg0', input_data))
 
     def test_extract_lvm_volgroup_no_size_set_to_zero_bytes(self, m_run):
@@ -269,10 +269,10 @@ class TestLvm(unittest.IsolatedAsyncioTestCase):
                      "vg_size": null}
                 ]"""))
         self.assertEqual(
-            ("vg0", {'name': "vg0",
-                     'devices': sorted(['/dev/md0', '/dev/md1']),
-                     'size': '0B',
-                     'partial': False}),
+            {'name': "vg0",
+             'devices': sorted(['/dev/md0', '/dev/md1']),
+             'size': '0B',
+             'partial': False},
             lvm.extract_lvm_volgroup('vg0', input_data))
 
     @mock.patch('probert.lvm.read_sys_block_size_bytes')


### PR DESCRIPTION
Previously, probert did not list a VG (or associated PVs) if there is no LV  inside of it.

Having the information about empty VGs is important when Subiquity generates the name of a VG to create. Indeed, the name it generates must not conflict with any existing ones, otherwise, LVM will refuse to create it.

Fixed by listing VGs that have no LV as well.

LP:#2143299

I also fixed an issue where probert would error-log "Found duplicate volume group" for all VG-s that have more than one LV.

For a VG with 11 LVs, we previously got 10 misleading "duplicates" errors:

```
2026-03-06 09:40:46,963 ERROR probert.lvm:233 Found duplicate volume group: testvg
2026-03-06 09:40:46,963 ERROR probert.lvm:233 Found duplicate volume group: testvg
2026-03-06 09:40:46,963 ERROR probert.lvm:233 Found duplicate volume group: testvg
2026-03-06 09:40:46,964 ERROR probert.lvm:233 Found duplicate volume group: testvg
2026-03-06 09:40:46,967 ERROR probert.lvm:233 Found duplicate volume group: testvg
2026-03-06 09:40:46,967 ERROR probert.lvm:233 Found duplicate volume group: testvg
2026-03-06 09:40:46,968 ERROR probert.lvm:233 Found duplicate volume group: testvg
2026-03-06 09:40:46,969 ERROR probert.lvm:233 Found duplicate volume group: testvg
2026-03-06 09:40:46,969 ERROR probert.lvm:233 Found duplicate volume group: testvg
2026-03-06 09:40:46,969 ERROR probert.lvm:233 Found duplicate volume group: testvg
```

which is obviously wrong.