### PR TITLE
Various fixes identified using an LLM

### DIFF
--- a/probert/dasd.py
+++ b/probert/dasd.py
@@ -141,9 +141,10 @@ async def probe(context=None, **kw):
         context = pyudev.Context()
 
     virtio_major = None
-    for line in open('/proc/devices'):
-        if line.endswith('virtblk\n'):
-            virtio_major = line.split()[0]
+    with open('/proc/devices') as proc_dev:
+        for line in proc_dev:
+            if line.endswith('virtblk\n'):
+                virtio_major = line.split()[0]
 
     log.debug("found MAJOR for virtblk: %s", virtio_major)
 

--- a/probert/dmcrypt.py
+++ b/probert/dmcrypt.py
@@ -40,7 +40,7 @@ def dmsetup_info(devname):
             ['sudo', 'dmsetup', 'info', devname, '-C', '-o',
              ','.join(fields), '--noheading', '--separator', _SEP])
     except subprocess.CalledProcessError as e:
-        log.error('Failed to probe dmsetup info:', e)
+        log.error('Failed to probe dmsetup info: %s', e)
         return None
     values = output.decode('utf-8').strip().split(_SEP)
     info = dict(zip(fields, values))

--- a/probert/firmware.py
+++ b/probert/firmware.py
@@ -38,7 +38,7 @@ schema = {
         "bios-version": {
             "type": ["string", "null"],
         },
-        "bios-release-data": {
+        "bios-release-date": {
             "type": ["string", "null"],
         },
     },

--- a/probert/mount.py
+++ b/probert/mount.py
@@ -34,7 +34,7 @@ def findmnt(data=None):
     try:
         mounts = json.loads(data)
     except json.decoder.JSONDecodeError as e:
-        log.error('Failed to load findmnt json output:', e)
+        log.error('Failed to load findmnt json output: %s', e)
 
     return mounts
 

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -225,9 +225,9 @@ class Storage():
 
         if len(to_probe) == 0:
             not_avail = probe_types.difference(all_probes)
-            print('Requsted probes not available: %s' % probe_types)
+            print('Requested probes not available: %s' % probe_types)
             print('Valid probe types: %s' % all_probes)
-            print('Unavilable probe types: %s' % not_avail)
+            print('Unavailable probe types: %s' % not_avail)
             return self.results
 
         probed_data = {}

--- a/probert/tests/test_dasd.py
+++ b/probert/tests/test_dasd.py
@@ -208,15 +208,13 @@ class TestDasd(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(expected_results, await dasd.probe(context=context))
 
     @mock.patch('probert.dasd.subprocess.run')
-    @mock.patch('probert.dasd.open')
     @mock.patch('probert.dasd.platform.machine')
-    async def test_dasd_probe_virtio_dasd(self, m_machine, m_open, m_run):
+    async def test_dasd_probe_virtio_dasd(self, m_machine, m_run):
         m_machine.return_value = 's390x'
 
         virtio_major = random_string()
         devname = random_string()
 
-        m_open.return_value = ['{} virtblk\n'.format(virtio_major)]
         m_run.return_value.returncode = 0
 
         context = mock.MagicMock()
@@ -226,28 +224,31 @@ class TestDasd(unittest.IsolatedAsyncioTestCase):
         expected_results = {
             devname: {'name': devname, 'type': 'virt'}
             }
-        self.assertEqual(expected_results, await dasd.probe(context=context))
+        with mock.patch('probert.dasd.open',
+                        mock.mock_open(read_data=f'{virtio_major} virtblk\n')):
+            self.assertEqual(expected_results,
+                             await dasd.probe(context=context))
         m_run.assert_called_once_with(
             ['fdasd', '-i', devname],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     @mock.patch('probert.dasd.subprocess.run')
-    @mock.patch('probert.dasd.open')
     @mock.patch('probert.dasd.platform.machine')
-    async def test_dasd_probe_virtio_non_dasd(self, m_machine, m_open, m_run):
+    async def test_dasd_probe_virtio_non_dasd(self, m_machine, m_run):
         m_machine.return_value = 's390x'
 
         virtio_major = random_string()
         devname = random_string()
 
-        m_open.return_value = ['{} virtblk\n'.format(virtio_major)]
         m_run.return_value.returncode = 1
 
         context = mock.MagicMock()
         context.list_devices.side_effect = iter([
             [{"MAJOR": virtio_major, "DEVNAME": devname}],
         ])
-        self.assertEqual({}, await dasd.probe(context=context))
+        with mock.patch('probert.dasd.open',
+                        mock.mock_open(read_data=f'{virtio_major} virtblk\n')):
+            self.assertEqual({}, await dasd.probe(context=context))
         m_run.assert_called_once_with(
             ['fdasd', '-i', devname],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/probert/tests/test_zfs.py
+++ b/probert/tests/test_zfs.py
@@ -31,3 +31,10 @@ tank\tquota\t0\tdefault
             cmd=['zfs'], returncode=1)
         result = zfs.zfs_get_properties('tank')
         self.assertEqual([], result)
+
+    @mock.patch('probert.zfs.subprocess.run')
+    def test_zfs_get_properties_empty_name(self, m_run):
+        with self.assertRaises(ValueError) as m_exc:
+            zfs.zfs_get_properties('')
+        self.assertEqual('Invalid zfs_name parameter: ""',
+                         str(m_exc.exception))

--- a/probert/tests/test_zfs.py
+++ b/probert/tests/test_zfs.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest import mock
+
+from probert import zfs
+
+
+class TestZfsGetProperties(unittest.TestCase):
+    @mock.patch('probert.zfs.subprocess.run')
+    def test_zfs_get_properties_ok(self, m_run):
+        output = '''\
+tank\ttype\tfilesystem\t-'
+tank\tused\t118272\t-
+tank\tquota\t0\tdefault
+'''
+        m_run.return_value.stdout = output.encode('utf-8')
+        result = zfs.zfs_get_properties('tank')
+        self.assertIn('tank', result)
+        self.assertEqual(
+                '118272',
+                result['tank']['properties']['used']['value'])
+        self.assertEqual('0', result['tank']['properties']['quota']['value'])
+        self.assertEqual(
+                'default',
+                result['tank']['properties']['quota']['source'])

--- a/probert/tests/test_zfs.py
+++ b/probert/tests/test_zfs.py
@@ -1,3 +1,4 @@
+import subprocess
 import unittest
 from unittest import mock
 
@@ -22,3 +23,11 @@ tank\tquota\t0\tdefault
         self.assertEqual(
                 'default',
                 result['tank']['properties']['quota']['source'])
+
+    @mock.patch('probert.zfs.subprocess.run')
+    def test_zfs_get_properties_returns_empty_on_calledprocesserror(
+            self, m_run):
+        m_run.side_effect = subprocess.CalledProcessError(
+            cmd=['zfs'], returncode=1)
+        result = zfs.zfs_get_properties('tank')
+        self.assertEqual([], result)

--- a/probert/zfs.py
+++ b/probert/zfs.py
@@ -156,7 +156,7 @@ def zfs_list_filesystems(raw_output=False):
 
 def zfs_get_properties(zfs_name, raw_output=False):
     if not zfs_name:
-        raise ValueError('Invalid zfs_name parameter: "%s"', zfs_name)
+        raise ValueError(f'Invalid zfs_name parameter: "{zfs_name}"')
 
     cmd = ['zfs', 'get', 'all', '-Hp', zfs_name]
     try:

--- a/probert/zfs.py
+++ b/probert/zfs.py
@@ -162,7 +162,7 @@ def zfs_get_properties(zfs_name, raw_output=False):
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
                                 stderr=subprocess.DEVNULL)
-    except subprocess.ProcessExecutionError:
+    except subprocess.CalledProcessError:
         return []
 
     data = result.stdout.decode('utf-8')


### PR DESCRIPTION
This PR fixes:
* two issues related to exception / error formatting.
* an except block trying to capture an undefined exception type (which is defined in `curtin.util`, not in probert, nor in `subprocess`)
* a file potentially staying open until garbage collection happens
* a misspelled property name in the JSON schema
* typos in user facing messages

Some tests added, covering the fixes.