### PR TITLE
probert: make failed commands actually produce CalledProcessError

### DIFF
--- a/probert/dasd.py
+++ b/probert/dasd.py
@@ -82,7 +82,8 @@ def dasdview(devname):
     cmd = ['dasdview', '--extended', devname]
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.DEVNULL)
+                                stderr=subprocess.DEVNULL,
+                                check=True)
     except (subprocess.CalledProcessError, FileNotFoundError):
         log.error('Failed to run cmd: %s', cmd)
         return None

--- a/probert/lvm.py
+++ b/probert/lvm.py
@@ -49,7 +49,8 @@ def _lvm_report(cmd, report_key):
 
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.DEVNULL)
+                                stderr=subprocess.DEVNULL,
+                                check=True)
         output = result.stdout.decode('utf-8')
     except subprocess.CalledProcessError as e:
         log.error('Failed to probe LVM devices on system: %s', e)
@@ -95,7 +96,8 @@ def lvm_scan():
             cmd.append('--cache')
         try:
             subprocess.run(cmd, stdout=subprocess.DEVNULL,
-                           stderr=subprocess.DEVNULL)
+                           stderr=subprocess.DEVNULL,
+                           check=True)
         except subprocess.CalledProcessError as e:
             log.error('Failed lvm_scan command %s: %s', cmd, e)
 

--- a/probert/mount.py
+++ b/probert/mount.py
@@ -24,7 +24,8 @@ def findmnt(data=None):
         cmd = ['findmnt', '--bytes', '--json', '-o', '+maj:min']
         try:
             result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                    stderr=subprocess.DEVNULL)
+                                    stderr=subprocess.DEVNULL,
+                                    check=True)
         except (subprocess.CalledProcessError, FileNotFoundError):
             return {}
 

--- a/probert/multipath.py
+++ b/probert/multipath.py
@@ -32,7 +32,8 @@ log = logging.getLogger('probert.multipath')
 def _extract_mpath_data(cmd, show_verb):
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.DEVNULL)
+                                stderr=subprocess.DEVNULL,
+                                check=True)
     except (subprocess.CalledProcessError, FileNotFoundError):
         log.error('Failed to run cmd: %s', cmd)
         return []

--- a/probert/raid.py
+++ b/probert/raid.py
@@ -32,7 +32,8 @@ SUPPORTED_RAID_TYPES = ['raid0', 'raid1', 'raid5', 'raid6', 'raid10']
 def mdadm_assemble(scan=True, ignore_errors=True):
     cmd = ['mdadm', '--detail', '--scan', '-v']
     try:
-        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                       check=True)
     except subprocess.CalledProcessError as e:
         log.error('Failed mdadm_assemble command %s: %s', cmd, e)
     except FileNotFoundError as e:
@@ -63,7 +64,8 @@ def get_mdadm_array_members(md_device):
     cmd = ['mdadm', '--detail', '--export', md_device]
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.DEVNULL)
+                                stderr=subprocess.DEVNULL,
+                                check=True)
         output = result.stdout.decode('utf-8')
     except subprocess.CalledProcessError as e:
         log.error('failed to get detail for %s: %s', md_device, e)

--- a/probert/storage.py
+++ b/probert/storage.py
@@ -114,7 +114,8 @@ async def blockdev_probe(context=None, **kw):
         cmd = ['sfdisk', '--bytes', '--json', devname]
         try:
             result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                    stderr=subprocess.DEVNULL)
+                                    stderr=subprocess.DEVNULL,
+                                    check=True)
             output = result.stdout.decode('utf-8')
         except subprocess.CalledProcessError as e:
             log.error('Failed to probe partition table on %s:%s', devname, e)

--- a/probert/tests/test_dasd.py
+++ b/probert/tests/test_dasd.py
@@ -6,6 +6,8 @@ from probert import dasd
 from probert.tests import fakes
 from probert.tests.helpers import random_string
 
+from parameterized import parameterized
+
 
 # The tests parse canned dasdview output, and to be able to write
 # tests one needs to simply know what the correct parsed values
@@ -60,7 +62,30 @@ class TestDasd(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(dasdview_out, result)
         m_run.assert_called_with(['dasdview', '--extended', devname],
                                  stdout=subprocess.PIPE,
-                                 stderr=subprocess.DEVNULL)
+                                 stderr=subprocess.DEVNULL,
+                                 check=True)
+
+    @parameterized.expand([
+        (subprocess.CalledProcessError(cmd=['dasdview'], returncode=1),),
+        (FileNotFoundError(),),
+    ])
+    def test_dasdview__failure(self, exc):
+        devname = '/dev/dasda'
+        expected_cmd = ['dasdview', '--extended', devname]
+        with mock.patch('probert.dasd.os.path.exists',
+                        return_value=True), \
+             mock.patch('probert.dasd.subprocess.run') as m_run:
+            m_run.side_effect = exc
+            with self.assertLogs('probert.dasd', level='ERROR') as logs:
+                result = dasd.dasdview(devname)
+        self.assertIsNone(result)
+        m_run.assert_called_with(
+                expected_cmd, stdout=mock.ANY, stderr=mock.ANY, check=True)
+        # Check that we logged the command that failed
+        self.assertEqual(len(logs.records), 1)
+        self.assertEqual(
+            logs.records[0].msg, 'Failed to run cmd: %s')
+        self.assertEqual(logs.records[0].args, (expected_cmd,))
 
     @mock.patch('probert.dasd.os.path.exists')
     @mock.patch('probert.dasd.subprocess.run')
@@ -69,15 +94,6 @@ class TestDasd(unittest.IsolatedAsyncioTestCase):
         m_exists.return_value = False
         self.assertRaises(ValueError, dasd.dasdview, devname)
         self.assertEqual(0, m_run.call_count)
-
-    @mock.patch('probert.dasd.os.path.exists')
-    @mock.patch('probert.dasd.subprocess.run')
-    def test_dasdview_returns_none_on_subprocess_error(self, m_run, m_exists):
-        devname = random_string()
-        m_exists.return_value = True
-        m_run.side_effect = subprocess.CalledProcessError(
-            cmd=[random_string()], returncode=1)
-        self.assertEqual(None, dasd.dasdview(devname))
 
     def test_dasd_parses_blocksize(self):
         self.assertEqual(

--- a/probert/tests/test_lvm.py
+++ b/probert/tests/test_lvm.py
@@ -71,11 +71,21 @@ VGS_REPORT_DUPES = 2 * VGS_REPORT
 @mock.patch('probert.lvm.subprocess.run')
 class TestLvm(unittest.IsolatedAsyncioTestCase):
 
-    def test__lvm_report_returns_empty_list_on_err(self, m_run):
-        m_run.side_effect = subprocess.CalledProcessError(
-            cmd=[random_string()], returncode=1)
-        result = lvm._lvm_report(random_string(), random_string())
+    def test__lvm_report__cmd_failure(self, m_run):
+        cmd = ['lvs', '--reportformat=json']
+        err = subprocess.CalledProcessError(cmd=cmd, returncode=1,
+                                            output=b'partial output')
+        m_run.side_effect = err
+        with self.assertLogs('probert.lvm', level='ERROR') as logs:
+            result = lvm._lvm_report(cmd, random_string())
         self.assertEqual([], result)
+        self.assertEqual(len(logs.records), 1)
+        self.assertEqual(logs.records[0].msg,
+                         'Failed to probe LVM devices on system: %s')
+        self.assertEqual(logs.records[0].args, (err,))
+        m_run.assert_called_with(
+            cmd, stdout=mock.ANY, stderr=mock.ANY,
+            check=True)
 
     def test__lvm_report_returns_empty_list_on_no_output(self, m_run):
         cmd_out = ""
@@ -179,9 +189,11 @@ class TestLvm(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(2, m_metad.call_count)
         m_run.assert_has_calls([
           mock.call(['pvscan', '--cache'],
-                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL),
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    check=True),
           mock.call(['vgscan', '--cache'],
-                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)])
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    check=True)])
 
     @mock.patch('probert.lvm.lvmetad_running')
     def test_lvm_scan_handles_errors(self, m_metad, m_run):
@@ -194,9 +206,11 @@ class TestLvm(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(2, m_metad.call_count)
         m_run.assert_has_calls([
           mock.call(['pvscan', '--cache'],
-                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL),
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    check=True),
           mock.call(['vgscan', '--cache'],
-                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)])
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    check=True)])
 
     def test_activate_volgroups(self, m_run):
         lvm.activate_volgroups()

--- a/probert/tests/test_mount.py
+++ b/probert/tests/test_mount.py
@@ -1,0 +1,53 @@
+import json
+import subprocess
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
+from probert import mount
+
+
+class TestFindmnt(unittest.TestCase):
+
+    @mock.patch('probert.mount.subprocess.run')
+    def test_findmnt_ok(self, m_run):
+        filesystems = [{'target': '/', 'fstype': 'ext4'}]
+        output = json.dumps({'filesystems': filesystems})
+        cp = subprocess.CompletedProcess(
+            args=['findmnt'], returncode=0,
+            stdout=output.encode('utf-8'), stderr='')
+        m_run.return_value = cp
+        result = mount.findmnt()
+        self.assertEqual(filesystems, result.get('filesystems'))
+        m_run.assert_called_once_with(
+            ['findmnt', '--bytes', '--json', '-o', '+maj:min'],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            check=True)
+
+    @parameterized.expand([
+        (subprocess.CalledProcessError(cmd=['findmnt'], returncode=1),),
+        (FileNotFoundError(),),
+    ])
+    def test_findmnt__failure(self, exc):
+        with mock.patch('probert.mount.subprocess.run') as m_run:
+            m_run.side_effect = exc
+            result = mount.findmnt()
+        self.assertEqual({}, result)
+        m_run.assert_called_once_with(
+            ['findmnt', '--bytes', '--json', '-o', '+maj:min'],
+            stdout=mock.ANY, stderr=mock.ANY,
+            check=True)
+
+    def test_findmnt_with_data(self):
+        filesystems = [{'target': '/', 'fstype': 'ext4'}]
+        data = json.dumps({'filesystems': filesystems})
+        result = mount.findmnt(data=data)
+        self.assertEqual(filesystems, result.get('filesystems'))
+
+    def test_findmnt_with_data_bad_json(self):
+        with self.assertLogs('probert.mount', level='ERROR') as logs:
+            result = mount.findmnt(data='not json')
+        self.assertEqual({}, result)
+        self.assertEqual(
+            logs.records[0].msg, 'Failed to load findmnt json output: %s')

--- a/probert/tests/test_multipath.py
+++ b/probert/tests/test_multipath.py
@@ -2,6 +2,8 @@ import subprocess
 import unittest
 from unittest import mock
 
+from parameterized import parameterized
+
 from probert import multipath
 from probert.tests.helpers import random_string
 
@@ -78,12 +80,34 @@ class TestMultipath(unittest.IsolatedAsyncioTestCase):
         result = multipath.multipath_show_maps()
         self.assertEqual(expected_result, result)
 
-    @mock.patch('probert.multipath.subprocess.run')
-    def test_multipath_extract_returns_empty_list_on_err(self, m_run):
-        m_run.side_effect = subprocess.CalledProcessError(cmd=["my cmd"],
-                                                          returncode=1)
-        result = multipath.multipath_show_paths()
+    @parameterized.expand([
+        (subprocess.CalledProcessError(
+            cmd=['multipathd', 'show', 'paths', 'raw', 'format',
+                 '%d,%z,%m,%N,%n,%R,%r,%a'],
+            returncode=1),
+         'Failed to run cmd: %s',
+         (['multipathd', 'show', 'paths', 'raw', 'format',
+           '%d,%z,%m,%N,%n,%R,%r,%a'],)),
+        (FileNotFoundError(),
+         'Failed to run cmd: %s',
+         (['multipathd', 'show', 'paths', 'raw', 'format',
+           '%d,%z,%m,%N,%n,%R,%r,%a'],)),
+    ])
+    def test__extract_mpath_data__failure(self, exc, exp_msg, exp_args):
+        cmd = ['multipathd', 'show', 'paths', 'raw', 'format',
+               '%d,%z,%m,%N,%n,%R,%r,%a']
+        with mock.patch('probert.multipath.subprocess.run') as m_run:
+            m_run.side_effect = exc
+            with self.assertLogs('probert.multipath', level='ERROR') as logs:
+                result = multipath._extract_mpath_data(cmd, 'paths')
         self.assertEqual([], result)
+        self.assertEqual(len(logs.records), 1)
+        self.assertEqual(logs.records[0].msg, exp_msg)
+        self.assertEqual(logs.records[0].args, exp_args)
+        m_run.assert_called_once_with(
+            cmd,
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            check=True)
 
     @mock.patch('probert.multipath.multipath_show_paths')
     @mock.patch('probert.multipath.multipath_show_maps')

--- a/probert/tests/test_raid.py
+++ b/probert/tests/test_raid.py
@@ -1,0 +1,75 @@
+import subprocess
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
+from probert import raid
+
+
+class TestMdadmAssemble(unittest.TestCase):
+
+    @parameterized.expand([
+        (subprocess.CalledProcessError(
+            cmd=['mdadm', '--detail', '--scan', '-v'], returncode=1),
+         'Failed mdadm_assemble command %s: %s',
+         (['mdadm', '--detail', '--scan', '-v'], mock.ANY)),
+        (FileNotFoundError(),
+         'Failed mdadm_assemble, mdadm command not found: %s',
+         (mock.ANY,)),
+    ])
+    def test_mdadm_assemble__failure(self, exc, exp_msg, exp_args):
+        with mock.patch('probert.raid.subprocess.run') as m_run:
+            m_run.side_effect = exc
+            with self.assertLogs('probert.raid', level='ERROR') as logs:
+                raid.mdadm_assemble()
+        self.assertEqual(logs.records[0].msg, exp_msg)
+        self.assertEqual(logs.records[0].args, exp_args)
+        m_run.assert_called_once_with(
+            ['mdadm', '--detail', '--scan', '-v'],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            check=True)
+
+
+class TestGetMdadmArrayMembers(unittest.TestCase):
+
+    @mock.patch('probert.raid.subprocess.run')
+    def test_get_mdadm_array_members_ok(self, m_run):
+        output = '\n'.join([
+            'MD_LEVEL=raid5',
+            'MD_DEVICES=3',
+            'MD_DEVICE_ev_dm_3_ROLE=1',
+            'MD_DEVICE_ev_dm_3_DEV=/dev/dm-3',
+            'MD_DEVICE_ev_dm_2_ROLE=0',
+            'MD_DEVICE_ev_dm_2_DEV=/dev/dm-2',
+            'MD_DEVICE_ev_dm_5_ROLE=spare',
+            'MD_DEVICE_ev_dm_5_DEV=/dev/dm-5',
+        ])
+        cp = subprocess.CompletedProcess(
+            args=['mdadm'], returncode=0,
+            stdout=output.encode('utf-8'), stderr='')
+        m_run.return_value = cp
+        actives, spares = raid.get_mdadm_array_members('/dev/md0')
+        self.assertEqual(['/dev/dm-2', '/dev/dm-3'], actives)
+        self.assertEqual(['/dev/dm-5'], spares)
+        m_run.assert_called_once_with(
+            ['mdadm', '--detail', '--export', '/dev/md0'],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            check=True)
+
+    def test_get_mdadm_array_members__calledprocesserror(self):
+        exc = subprocess.CalledProcessError(
+            cmd=['mdadm', '--detail', '--export', '/dev/md0'], returncode=1)
+        with mock.patch('probert.raid.subprocess.run') as m_run:
+            m_run.side_effect = exc
+            with self.assertLogs('probert.raid', level='ERROR') as logs:
+                result = raid.get_mdadm_array_members('/dev/md0')
+        self.assertEqual(([], []), result)
+        self.assertEqual(
+            logs.records[0].msg, 'failed to get detail for %s: %s')
+        self.assertEqual(
+            logs.records[0].args, ('/dev/md0', exc))
+        m_run.assert_called_once_with(
+            ['mdadm', '--detail', '--export', '/dev/md0'],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            check=True)

--- a/probert/tests/test_storage.py
+++ b/probert/tests/test_storage.py
@@ -1,8 +1,11 @@
+import subprocess
 import unittest
+from unittest import mock
 from unittest.mock import AsyncMock, Mock
 import json
 
-from probert.storage import Storage, StorageInfo, interesting_storage_devs
+from probert.storage import (Storage, StorageInfo, blockdev_probe,
+                             interesting_storage_devs)
 from probert.tests.fakes import FAKE_PROBE_ALL_JSON
 
 from parameterized import parameterized
@@ -85,6 +88,42 @@ class ProbertTestStorageProbeSet(unittest.IsolatedAsyncioTestCase):
         await self.storage.probe(probe_types)
         for v in self.storage.probe_map.values():
             v.pfunc.assert_not_called()
+
+
+class TestBlockdevProbe(unittest.IsolatedAsyncioTestCase):
+    # Lots of mocks because _extract_partition_table is a nested function
+    # inside blockdev_probe — testing sfdisk's failure path requires
+    # patching everything that blockdev_probe touches.
+    @mock.patch('probert.storage.subprocess.run')
+    @mock.patch('probert.storage.read_sys_block_size_bytes')
+    @mock.patch('probert.storage.udev_get_attributes')
+    @mock.patch('probert.storage.interesting_storage_devs')
+    @mock.patch('probert.storage.pyudev')
+    async def test_extract_partition_table_sfdisk_failure(
+            self, m_pyudev, m_interesting, m_udev_attr, m_read_sys, m_run):
+        devname = '/dev/sda'
+        m_interesting.return_value = [
+            mock.MagicMock(
+                properties={'DEVNAME': devname})]
+        m_udev_attr.return_value = {'size': '1000'}
+        m_read_sys.return_value = 1000
+        err = subprocess.CalledProcessError(
+            cmd=['sfdisk'], returncode=1)
+        m_run.side_effect = err
+
+        with self.assertLogs('probert.storage', level='ERROR') as logs:
+            result = await blockdev_probe(context=mock.MagicMock())
+        self.assertIn(devname, result)
+        self.assertNotIn('pttype', result[devname])
+        self.assertEqual(len(logs.records), 1)
+        self.assertEqual(
+            logs.records[0].msg,
+            'Failed to probe partition table on %s:%s')
+        self.assertEqual(logs.records[0].args, (devname, err))
+        m_run.assert_called_with(
+            ['sfdisk', '--bytes', '--json', devname],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            check=True)
 
 
 class ProbertTestStorageInfo(unittest.TestCase):

--- a/probert/tests/test_zfs.py
+++ b/probert/tests/test_zfs.py
@@ -2,7 +2,73 @@ import subprocess
 import unittest
 from unittest import mock
 
+from parameterized import parameterized
+
 from probert import zfs
+
+
+class TestZdbAsdict(unittest.TestCase):
+    @mock.patch('probert.zfs.os.path.exists')
+    @mock.patch('probert.zfs.subprocess.run')
+    def test_zdb_asdict_with_data(self, m_run, m_exists):
+        m_exists.return_value = True
+        result = zfs.zdb_asdict(data='test_pool:\n    version: 5000\n')
+        self.assertIn('test_pool', result)
+        m_run.assert_not_called()
+
+    @parameterized.expand([
+        (subprocess.CalledProcessError(cmd=['zdb'], returncode=1),),
+        (FileNotFoundError(),),
+    ])
+    def test_zdb_asdict__failure(self, exc):
+        with mock.patch('probert.zfs.os.path.exists',
+                        return_value=True), \
+             mock.patch('probert.zfs.subprocess.run') as m_run:
+            m_run.side_effect = exc
+            result = zfs.zdb_asdict()
+        self.assertEqual({}, result)
+        m_run.assert_called_once_with(
+            ['zdb'],
+            stdout=mock.ANY, stderr=mock.ANY,
+            check=True)
+
+
+class TestZfsListFilesystems(unittest.TestCase):
+    @mock.patch('probert.zfs.subprocess.run')
+    def test_zfs_list_filesystems_ok(self, m_run):
+        output = 'tank\t118272\t0\t118272\t/\n'
+        cp = subprocess.CompletedProcess(
+            args=['zfs'], returncode=0,
+            stdout=output.encode('utf-8'), stderr='')
+        m_run.return_value = cp
+        result = zfs.zfs_list_filesystems()
+        self.assertEqual(1, len(result))
+        self.assertEqual('tank', result[0].name)
+        m_run.assert_called_once_with(
+            ['zfs', 'list', '-Hp', '-t', 'filesystem'],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            check=True)
+
+    @mock.patch('probert.zfs.subprocess.run')
+    def test_zfs_list_filesystems__calledprocesserror(self, m_run):
+        m_run.side_effect = subprocess.CalledProcessError(
+            cmd=['zfs'], returncode=1)
+        result = zfs.zfs_list_filesystems()
+        self.assertEqual([], result)
+        m_run.assert_called_once_with(
+            ['zfs', 'list', '-Hp', '-t', 'filesystem'],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            check=True)
+
+    @mock.patch('probert.zfs.subprocess.run')
+    def test_zfs_list_filesystems_raw(self, m_run):
+        output = 'tank\t118272\t0\t118272\t/\n'
+        cp = subprocess.CompletedProcess(
+            args=['zfs'], returncode=0,
+            stdout=output.encode('utf-8'), stderr='')
+        m_run.return_value = cp
+        result = zfs.zfs_list_filesystems(raw_output=True)
+        self.assertEqual(output, result)
 
 
 class TestZfsGetProperties(unittest.TestCase):
@@ -25,12 +91,16 @@ tank\tquota\t0\tdefault
                 result['tank']['properties']['quota']['source'])
 
     @mock.patch('probert.zfs.subprocess.run')
-    def test_zfs_get_properties_returns_empty_on_calledprocesserror(
+    def test_zfs_get_properties__calledprocesserror(
             self, m_run):
         m_run.side_effect = subprocess.CalledProcessError(
             cmd=['zfs'], returncode=1)
         result = zfs.zfs_get_properties('tank')
         self.assertEqual([], result)
+        m_run.assert_called_once_with(
+            ['zfs', 'get', 'all', '-Hp', 'tank'],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            check=True)
 
     @mock.patch('probert.zfs.subprocess.run')
     def test_zfs_get_properties_empty_name(self, m_run):

--- a/probert/zfs.py
+++ b/probert/zfs.py
@@ -122,7 +122,8 @@ def zdb_asdict(data=None):
             cmd.append('-e')
         try:
             result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                    stderr=subprocess.DEVNULL)
+                                    stderr=subprocess.DEVNULL,
+                                    check=True)
         except (subprocess.CalledProcessError, FileNotFoundError):
             return {}
 
@@ -135,7 +136,8 @@ def zfs_list_filesystems(raw_output=False):
     cmd = ['zfs', 'list', '-Hp', '-t', 'filesystem']
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.DEVNULL)
+                                stderr=subprocess.DEVNULL,
+                                check=True)
     except subprocess.CalledProcessError:
         return []
 
@@ -161,7 +163,8 @@ def zfs_get_properties(zfs_name, raw_output=False):
     cmd = ['zfs', 'get', 'all', '-Hp', zfs_name]
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.DEVNULL)
+                                stderr=subprocess.DEVNULL,
+                                check=True)
     except subprocess.CalledProcessError:
         return []
 


### PR DESCRIPTION
In multiple places, probert had `except subprocess.CalledProcessError` blocks around calls to `subprocess.run()`. However, such an exception can only be raised when `check=True` is passed.

This means the except `subprocess.CalledProcessError` blocks where essentially unreachable, and only covered by mock side effects.

We now pass `check=True` to all relevant commands.

Note that commands failing with output would previously be parsed as if they succeeded. With this change, parsing will be skipped if the commands fail.

Originally, this bug was pointed out by @copilot in #169.